### PR TITLE
Add skeleton for Repo Structure, Build, Test and CI systems

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AlwaysBreakTemplateDeclarations:  true
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 FixNamespaceComments: false
-Standard: Cpp17
+Standard: Auto
 ColumnLimit: 80
 AllowAllParametersOfDeclarationOnNextLine: true
 AlignEscapedNewlines: Right

--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -16,32 +16,61 @@ jobs:
     env:
       GH_YML_JOBNAME: ${{ matrix.jobname }}
       GH_YML_OS: Linux
-      
     strategy:
       fail-fast: false
       matrix:
         jobname: [
-          ubuntu
+          ubuntu18-gcc7
         ]
-    
+
     steps:
-    - name: Update System Repos
-      run: /bin/sh -c "sudo apt-get update"
-
-    - name: Setup Dependencies
-      run: /bin/sh -c "sudo apt-get install ninja-build python3-pip python3-setuptools -y && sudo pip3 install meson"
-
     - name: Checkout Action
       uses: actions/checkout@v1
+      
+    - name: Setup Dependencies
+      run: scripts/ci/github-actions/bash/setup_debian.sh
 
     - name: Configure
-      run: /bin/sh -c "cd ${GITHUB_WORKSPACE}/.. && mkdir ncio-build && cd ncio-build && meson --prefix=${GITHUB_WORKSPACE}/../ncio-install ${GITHUB_WORKSPACE}"
+      run: scripts/ci/github-actions/bash/run_step.sh configure
 
     - name: Build
-      run: /bin/sh -c "cd ${GITHUB_WORKSPACE}/../ncio-build && ninja"
+      run: scripts/ci/github-actions/bash/run_step.sh build
 
     - name: Test
-      run: /bin/sh -c "cd ${GITHUB_WORKSPACE}/../ncio-build && ninja test"
+      run: scripts/ci/github-actions/bash/run_step.sh test
 
     - name: Install
-      run: /bin/sh -c "cd ${GITHUB_WORKSPACE}/../ncio-build && ninja install"
+      run: scripts/ci/github-actions/bash/run_step.sh install
+
+
+#   macos:
+#     runs-on: macos-latest
+#     env:
+#       GH_YML_JOBNAME: ${{ matrix.jobname }}
+#       GH_YML_OS: macOS
+# 
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         jobname: [
+#           macos1015-xcode11 
+#         ]
+# 
+#     steps:
+#     - name: Checkout Action
+#       uses: actions/checkout@v1
+# 
+#     - name: Setup Dependencies
+#       run: scripts/ci/github-actions/bash/setup_macos.sh
+# 
+#     - name: Configure
+#       run: scripts/ci/github-actions/bash/run_step.sh configure
+# 
+#     - name: Build
+#       run: scripts/ci/github-actions/bash/run_step.sh build
+# 
+#     - name: Test
+#       run: scripts/ci/github-actions/bash/run_step.sh test
+# 
+#     - name: Install
+#       run: scripts/ci/github-actions/bash/run_step.sh install

--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -29,13 +29,13 @@ jobs:
       run: /bin/sh -c "sudo apt-get update"
 
     - name: Setup Dependencies
-      run: /bin/sh -c "sudo apt-get install ninja-build meson -y"
+      run: /bin/sh -c "sudo apt-get install ninja-build python3-pip python3-setuptools -y && sudo pip3 install meson"
 
     - name: Checkout Action
       uses: actions/checkout@v1
 
     - name: Configure
-      run: /bin/sh -c "cd ${GITHUB_WORKSPACE}/.. && mkdir ncio-build && cd ncio-build && meson --prefix=${GITHUB_WORKSPACE}/../ncio-install .."
+      run: /bin/sh -c "cd ${GITHUB_WORKSPACE}/.. && mkdir ncio-build && cd ncio-build && meson --prefix=${GITHUB_WORKSPACE}/../ncio-install ${GITHUB_WORKSPACE}"
 
     - name: Build
       run: /bin/sh -c "cd ${GITHUB_WORKSPACE}/../ncio-build && ninja"

--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -14,21 +14,31 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     env:
-      GH_YML_JOBNAME: ${{ matrix.jobname }}
-      GH_YML_OS: Linux
+      GH_JOBNAME: ${{ matrix.jobname }}
+      GH_OS: Linux
     strategy:
       fail-fast: false
       matrix:
         jobname: [
-          ubuntu18-gcc7
+          ubuntu18-gcc7,
+          centos7-gcc7
         ]
+        include:
+        - jobname: ubuntu18-gcc7
+          container: 
+            image: devcafe/ubuntu18.04-gcc7.3.0-openmpi2.1.0
+            options: -u root
+        - jobname: centos7-gcc7
+          container: 
+            image: centos/devtoolset-7-toolchain-centos7:7
+            options: -u root
 
     steps:
     - name: Checkout Action
       uses: actions/checkout@v1
       
     - name: Setup Dependencies
-      run: scripts/ci/github-actions/bash/setup_debian.sh
+      run: scripts/ci/github-actions/bash/setup_linux.sh
 
     - name: Configure
       run: scripts/ci/github-actions/bash/run_step.sh configure
@@ -43,34 +53,34 @@ jobs:
       run: scripts/ci/github-actions/bash/run_step.sh install
 
 
-#   macos:
-#     runs-on: macos-latest
-#     env:
-#       GH_YML_JOBNAME: ${{ matrix.jobname }}
-#       GH_YML_OS: macOS
-# 
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         jobname: [
-#           macos1015-xcode11 
-#         ]
-# 
-#     steps:
-#     - name: Checkout Action
-#       uses: actions/checkout@v1
-# 
-#     - name: Setup Dependencies
-#       run: scripts/ci/github-actions/bash/setup_macos.sh
-# 
-#     - name: Configure
-#       run: scripts/ci/github-actions/bash/run_step.sh configure
-# 
-#     - name: Build
-#       run: scripts/ci/github-actions/bash/run_step.sh build
-# 
-#     - name: Test
-#       run: scripts/ci/github-actions/bash/run_step.sh test
-# 
-#     - name: Install
-#       run: scripts/ci/github-actions/bash/run_step.sh install
+  macos:
+    runs-on: macos-latest
+    env:
+      GH_YML_JOBNAME: ${{ matrix.jobname }}
+      GH_YML_OS: macOS
+
+    strategy:
+      fail-fast: false
+      matrix:
+        jobname: [
+          macos1015-xcode11 
+        ]
+
+    steps:
+    - name: Checkout Action
+      uses: actions/checkout@v1
+
+    - name: Setup Dependencies
+      run: scripts/ci/github-actions/bash/setup_macos.sh
+
+    - name: Configure
+      run: scripts/ci/github-actions/bash/run_step.sh configure
+
+    - name: Build
+      run: scripts/ci/github-actions/bash/run_step.sh build
+
+    - name: Test
+      run: scripts/ci/github-actions/bash/run_step.sh test
+
+    - name: Install
+      run: scripts/ci/github-actions/bash/run_step.sh install

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,6 @@ CMakeSettings.json
 *.gch
 *.pch
 
+# Meson subprojects
+subprojects/doctest
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # ncio
 Neutrons Common Input Output, SNS/HFIR neutrons data management framework
+
+
+## Installing from source with [Meson](https://mesonbuild.com/)
+
+1. Requirements:
+
+    - meson build >= 0.52.0, from `pip3 install meson` 
+    - ninja
+    - mono-complete (might be already installed on Ubuntu 18, 20, or macOS)
+
+2. Build, Test, Install:
+
+    We highly recommend truly out-of-source builds (completely outside the repo directory).
+
+    ```
+    $ mkdir ncio-build
+    $ cd ncio-build
+    $ meson --prefix=/path/to/install/ncio  /path/to/repo/ncio
+    $ ninja
+    $ ninja test
+    $ ninja install
+    ```
+
+    
+## Directory layout
+* bindings - Public application programming interface, API, language bindings (C++17)
+
+* scripts - Project maintenance and development scripts
+
+* source - Internal source code for private components and public common headers to be installed
+    * ncio - source directory for the ncio library to be installed as prefix/lib/libncio.*  
+
+* testing - Tests unit and functional using [doctest](https://github.com/onqtam/doctest)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 Neutrons Common Input Output, SNS/HFIR neutrons data management framework
 
 
-## Installing from source with [Meson](https://mesonbuild.com/)
+## Installing ncio from source with [Meson](https://mesonbuild.com/)
 
 1. Requirements:
 
     - meson build >= 0.52.0, from `pip3 install meson` 
     - ninja
     - mono-complete (might be already installed on Ubuntu 18, 20, or macOS)
+    - pkg-config
 
 2. Build, Test, Install:
 
@@ -22,8 +23,48 @@ Neutrons Common Input Output, SNS/HFIR neutrons data management framework
     $ ninja test
     $ ninja install
     ```
-
     
+3. Code coverage from tests (requires gcov)
+
+   Meson can generate code coverage reports automatically from tests. 
+   Requires passing `-Db_coverage=true` when configuring and running the `coverage` target.
+   Reports would be generated under the `meson-logs` directory 
+
+    ```
+    $ mkdir ncio-build
+    $ cd ncio-build
+    $ meson --prefix=/path/to/install/ncio -Db_coverage=true /path/to/repo/ncio
+    $ ninja 
+    $ ninja coverage
+    [1/1] Generates coverage reports
+	lines: 45.8% (11 out of 24)
+	branches: 34.6% (9 out of 26)
+
+	Xml coverage report can be found at file:///Users/wfg/workspace/ncio-build/meson-logs/coverage.xml
+	Text coverage report can be found at file:///Users/wfg/workspace/ncio-build/meson-logs/coverage.txt
+	Html coverage report can be found at file:///Users/wfg/workspace/ncio-build/meson-logs/coveragereport/index.html
+	```
+
+## Linking ncio with CMake projects
+
+Meson uses `pkg-config` as a standard packaging configuration method. 
+Make sure ncio installation directory is reachable, so pc configuration files can be found. 
+One of the methods is to pass `-DCMAKE_PREFIX_PATH=/installation/to/ncio` at configuration.
+ncio can be easily be integrated with `CMake` projects via the [FindPkgConfig](https://cmake.org/cmake/help/latest/module/FindPkgConfig.html) module.
+The following snippet illustrates how to create a ncio target and link it to a `CMake` target.
+	
+	```
+	# find pkg-config
+	find_package(PkgConfig REQUIRED) 
+	# create target `PkgConfig::ncio`
+	pkg_check_modules(ncio REQUIRED IMPORTED_TARGET ncio)
+	# create a CMake target (_e.g._ executable)
+	add_executable(ncio_cmake ncio_cmake.cpp)
+	# link with PkgConfig::ncio target
+	target_link_libraries(ncio_cmake PUBLIC PkgConfig::ncio)
+	
+	```
+
 ## Directory layout
 * bindings - Public application programming interface, API, language bindings (C++17)
 

--- a/bindings/CXX17/meson.build
+++ b/bindings/CXX17/meson.build
@@ -1,0 +1,27 @@
+# MESON file to build the ncio-cxx17 bindings library
+#  Created on: May 11, 2020
+#      Author: William F Godoy godoywf@ornl.gov  
+
+
+ncio_cxx17_src = ['ncio/cxx17/cxx17NCIO.cpp']
+ncio_cxx17_inc = include_directories(['ncio/cxx17'])
+
+ncio_cxx17_lib = library('ncio-cxx17', 
+                         sources: ncio_cxx17_src,
+                         include_directories: ncio_cxx17_inc,
+                         dependencies : [ncio_dep],
+                         install: true)
+
+# installation headers
+# only public header that should be included in projects using ncio
+install_headers('ncio.h')
+
+# other CXX17 headers 
+headers_cxx17 = ['cxx17NCIO.h']
+
+# meson is not Turing-complete, so user-defined functions are not possible
+# list + loop is a great and clean workaround
+# install in -> include/ncio/cxx17/header.h
+foreach header_cxx17 : headers_cxx17
+  install_headers('ncio/cxx17/'+header_cxx17, subdir:'ncio/cxx17')
+endforeach

--- a/bindings/CXX17/ncio.h
+++ b/bindings/CXX17/ncio.h
@@ -1,0 +1,12 @@
+/*
+ * ncio.h : unique public header. Projects using ncio should only include this
+ * header
+ *
+ *  Created on: May 8, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include "ncio/common/ncioTypes.h"
+#include "ncio/cxx17/cxx17NCIO.h"

--- a/bindings/CXX17/ncio/cxx17/cxx17NCIO.cpp
+++ b/bindings/CXX17/ncio/cxx17/cxx17NCIO.cpp
@@ -1,0 +1,24 @@
+
+#include "cxx17NCIO.h"
+
+#include "ncio/core/NCIO.h"
+
+namespace ncio
+{
+
+NCIO::NCIO(const std::string &configFile)
+: m_NCIO(std::make_unique<core::NCIO>(configFile))
+{
+}
+
+void NCIO::SetParameter(const std::string key, const std::string value) noexcept
+{
+    m_NCIO->SetParameter(key, value);
+}
+
+std::string NCIO::GetParameter(const std::string key) noexcept
+{
+    return m_NCIO->GetParameter(key);
+}
+
+} // end namespace ncio

--- a/bindings/CXX17/ncio/cxx17/cxx17NCIO.cpp
+++ b/bindings/CXX17/ncio/cxx17/cxx17NCIO.cpp
@@ -11,12 +11,19 @@ NCIO::NCIO(const std::string &configFile)
 {
 }
 
+NCIO::~NCIO() {}
+
+std::string NCIO::GetConfigFile() const noexcept
+{
+    return m_NCIO->GetConfigFile();
+}
+
 void NCIO::SetParameter(const std::string key, const std::string value) noexcept
 {
     m_NCIO->SetParameter(key, value);
 }
 
-std::string NCIO::GetParameter(const std::string key) noexcept
+std::string NCIO::GetParameter(const std::string key) const noexcept
 {
     return m_NCIO->GetParameter(key);
 }

--- a/bindings/CXX17/ncio/cxx17/cxx17NCIO.h
+++ b/bindings/CXX17/ncio/cxx17/cxx17NCIO.h
@@ -28,7 +28,18 @@ public:
      * (yaml?)
      */
     NCIO(const std::string &configFile = "");
-    ~NCIO() = default;
+
+    /**
+     * Can't use default destructor since std::unique_ptr private implementation
+     * can't have incomplete types
+     */
+    ~NCIO();
+
+    /**
+     * Get configuration file name passed in constructor
+     * @return configuration file name
+     */
+    std::string GetConfigFile() const noexcept;
 
     /**
      * Set a specific configuration parameter, meant to be equivalent to values
@@ -45,7 +56,7 @@ public:
      * @param key input parameter key to search in existing set parameters.
      * @return parameter value, if key not found returns an empty string.
      */
-    std::string GetParameter(const std::string key) noexcept;
+    std::string GetParameter(const std::string key) const noexcept;
 
 private:
     /** private implementation pointer */

--- a/bindings/CXX17/ncio/cxx17/cxx17NCIO.h
+++ b/bindings/CXX17/ncio/cxx17/cxx17NCIO.h
@@ -1,0 +1,55 @@
+/**
+ * cxx17NCIO.h : public C++17 header to the NCIO class
+ *
+ *  Created on: May 8, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include <memory> //std::unique_ptr
+#include <string>
+
+namespace ncio
+{
+
+namespace core
+{
+class NCIO; // forward declare private implementation
+}
+
+class NCIO
+{
+public:
+    /**
+     * NCIO constructor, it's the starting point of contact within the NCIO
+     * library and an application
+     * @param configFile optional input runtime configuration TODO format
+     * (yaml?)
+     */
+    NCIO(const std::string &configFile = "");
+    ~NCIO() = default;
+
+    /**
+     * Set a specific configuration parameter, meant to be equivalent to values
+     * in constructor's configFile Using small string optimization SSO (passing
+     * by value) as parameters are expected to be small strings. If key exists
+     * it replaces the current value.
+     * @param key input parameter key
+     * @param value input parameter value
+     */
+    void SetParameter(const std::string key, const std::string value) noexcept;
+
+    /**
+     * Returns the value of a parameter found by key.
+     * @param key input parameter key to search in existing set parameters.
+     * @return parameter value, if key not found returns an empty string.
+     */
+    std::string GetParameter(const std::string key) noexcept;
+
+private:
+    /** private implementation pointer */
+    std::unique_ptr<core::NCIO> m_NCIO;
+};
+
+} // end namespace ncio

--- a/bindings/meson.build
+++ b/bindings/meson.build
@@ -1,0 +1,1 @@
+subdir('CXX17')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,24 @@
+# MESON build main file
+#  Created on: May 11, 2020
+#      Author: William F Godoy godoywf@ornl.gov
+
+# Define project information
+project('ncio',
+        list_of_languages: ['cpp'],
+        license: 'BSD 3-Clause',
+        version: '0.0.1',
+        meson_version: '>=0.52.0',
+        default_options: ['cpp_std=c++17', 'buildtype=debug', 'layout=flat']
+)
+
+# private ncio library
+subdir('source')
+
+# bindings depend on ncio library
+subdir('bindings')
+
+# tests
+if get_option('build-tests')
+  doctest_dep = dependency('doctest', fallback: ['doctest', 'doctest_dep'])
+  subdir('testing')
+endif

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 
 # Define project information
 project('ncio',
-        list_of_languages: ['cpp'],
+        ['cpp'],
         license: 'BSD 3-Clause',
         version: '0.0.1',
         meson_version: '>=0.52.0',

--- a/meson.build
+++ b/meson.build
@@ -22,3 +22,14 @@ if get_option('build-tests')
   doctest_dep = dependency('doctest', fallback: ['doctest', 'doctest_dep'])
   subdir('testing')
 endif
+
+# pkg-config generation
+# Meson uses pkg-config for library consumption.
+# This module sets libraries (private and public) to link against
+# pkg-config is supported by CMake based products
+pkg = import('pkgconfig')
+pkg.generate(libraries : ncio_cxx17_lib,
+             version : '0.0.1',
+             filebase : 'ncio',
+             name : 'ncio',
+             description : 'NCIO library')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+# File provides accepted options for ncio build configuration
+#  Created on: May 11, 2020
+#      Author: William F Godoy godoywf@ornl.gov
+
+option('build-tests', type : 'boolean', value : true)

--- a/scripts/ci/github-actions/bash/run_step.sh
+++ b/scripts/ci/github-actions/bash/run_step.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Run specific steps based on input
+
+case "$1" in 
+
+  # Configure ncio using meson using out-of-source builds 
+  configure)
+    cd ${GITHUB_WORKSPACE}/..
+    mkdir ncio-build
+    cd ncio-build
+    meson --prefix=${GITHUB_WORKSPACE}/../ncio-install ${GITHUB_WORKSPACE}
+    ;;
+
+  # Build using ninja
+  build)
+    cd ${GITHUB_WORKSPACE}/../ncio-build
+    ninja
+    ;;
+
+  # Run all tests
+  test)
+    cd ${GITHUB_WORKSPACE}/../ncio-build
+    ninja test
+    ;;
+
+  # Install the library (
+  install)
+    cd ${GITHUB_WORKSPACE}/../ncio-build
+    ninja test
+    ;;
+
+  *)
+    echo " Invalid step" "$1"
+    exit -1
+    ;;
+esac

--- a/scripts/ci/github-actions/bash/setup_centos7.sh
+++ b/scripts/ci/github-actions/bash/setup_centos7.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Only updating, upgrading can be slow. Might create a new container in the future
+yum update -y
+
+# Get dependencies
+# git 2.22.0
+yum install http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm -y
+yum install git -y
+
+# ninja 1.8x
+yum install http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm -y
+yum install ninja-build  -y
+
+# Get a more recen meson v0.54 from pip3
+yum install python3-pip -y
+pip3 install meson

--- a/scripts/ci/github-actions/bash/setup_debian.sh
+++ b/scripts/ci/github-actions/bash/setup_debian.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Only updating, upgrading can be slow. Might create a new container in the future
-sudo apt-get update
+apt-get update
 
 # Get dependencies
-sudo apt-get install ninja-build python3-pip python3-setuptools -y
+apt-get install ninja-build python3-pip python3-setuptools -y
 
 # Get a more recen meson v0.54 from pip3
-sudo pip3 install meson
+pip3 install meson

--- a/scripts/ci/github-actions/bash/setup_debian.sh
+++ b/scripts/ci/github-actions/bash/setup_debian.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Only updating, upgrading can be slow. Might create a new container in the future
+sudo apt-get update
+
+# Get dependencies
+sudo apt-get install ninja-build python3-pip python3-setuptools -y
+
+# Get a more recen meson v0.54 from pip3
+sudo pip3 install meson

--- a/scripts/ci/github-actions/bash/setup_linux.sh
+++ b/scripts/ci/github-actions/bash/setup_linux.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+
+case "${GH_JOBNAME}" in
+
+  *"centos7"*)
+    ${GITHUB_WORKSPACE}/scripts/ci/github-actions/bash/setup_centos7.sh
+    ;;
+    
+  *"ubuntu"*)
+    ${GITHUB_WORKSPACE}/scripts/ci/github-actions/bash/setup_debian.sh
+    ;;
+esac

--- a/scripts/ci/github-actions/bash/setup_macOS.sh
+++ b/scripts/ci/github-actions/bash/setup_macOS.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+brew install ninja
+brew install meson

--- a/source/meson.build
+++ b/source/meson.build
@@ -1,0 +1,1 @@
+subdir('ncio')

--- a/source/ncio/common/ncioTypes.h
+++ b/source/ncio/common/ncioTypes.h
@@ -1,0 +1,13 @@
+/*
+ * ncioTypes.h : define public types in the ncio library.
+ *
+ *  Created on: May 9, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include <cstddef> //std::size_t
+#include <limits>  //std::numeric_limits
+
+#include "ncioTypesNexus.h"

--- a/source/ncio/common/ncioTypesNexus.h
+++ b/source/ncio/common/ncioTypesNexus.h
@@ -1,0 +1,84 @@
+/*
+ * ncioTypesNexus.h : public header that defines specific NeXus types
+ *
+ *  Created on: May 11, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+/**
+ * Define inputs to NCIO API functions that are specific to the NeXus schema
+ * types mapping to datasets or variables.
+ * Info about the NeXus schema: https://manual.nexusformat.org/index.html
+ */
+namespace ncio::nexus
+{
+
+enum class bank
+{
+    event_id,
+    event_index,
+    event_time_offset,
+    event_time_zero,
+    total_counts
+};
+
+constexpr std::size_t bank_error = std::numeric_limits<std::size_t>::max() - 1;
+constexpr std::size_t bank_unmapped =
+    std::numeric_limits<std::size_t>::max() - 2;
+
+enum class log
+{
+    average_value,
+    average_value_error,
+    device_id,
+    device_name,
+    maximum_value,
+    minimum_value,
+    time,
+    value
+};
+
+enum class sample
+{
+    can_barcode,
+    can_indicator,
+    can_materials,
+    can_name,
+    chemical_formula,
+    comments,
+    component,
+    container_id,
+    container_name,
+    description,
+    height_in_container,
+    identifier,
+    interior_depth,
+    interior_diameter,
+    interior_height,
+    interior_width,
+    lattice_a,
+    lattice_alpha,
+    lattice_b,
+    lattice_beta,
+    lattice_c,
+    lattice_gamma,
+    mass,
+    mass_density,
+    name,
+    nature,
+    outer_depth,
+    outer_diameter,
+    outer_height,
+    outer_width,
+    volume_cubic
+};
+
+enum class user
+{
+    facility_user_id,
+    name
+};
+
+} // end namespace ncio::nexus

--- a/source/ncio/core/NCIO.cpp
+++ b/source/ncio/core/NCIO.cpp
@@ -1,0 +1,28 @@
+/**
+ * NCIO.h : private C++17 implementation to the core::NCIO class
+ *
+ *  Created on: May 8, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#include "NCIO.h"
+
+namespace ncio::core
+{
+
+NCIO::NCIO(const std::string &configFile) : m_ConfigFile(configFile) {}
+
+void NCIO::SetParameter(const std::string key, const std::string value) noexcept
+{
+    m_Parameters[key] = value;
+}
+
+std::string NCIO::GetParameter(const std::string key) noexcept
+{
+    auto itKey = m_Parameters.find(key);
+    const std::string value =
+        (itKey == m_Parameters.end()) ? "" : itKey->second;
+    return value;
+}
+
+} // end namespace ncio::core

--- a/source/ncio/core/NCIO.cpp
+++ b/source/ncio/core/NCIO.cpp
@@ -12,12 +12,14 @@ namespace ncio::core
 
 NCIO::NCIO(const std::string &configFile) : m_ConfigFile(configFile) {}
 
+std::string NCIO::GetConfigFile() const noexcept { return m_ConfigFile; }
+
 void NCIO::SetParameter(const std::string key, const std::string value) noexcept
 {
     m_Parameters[key] = value;
 }
 
-std::string NCIO::GetParameter(const std::string key) noexcept
+std::string NCIO::GetParameter(const std::string key) const noexcept
 {
     auto itKey = m_Parameters.find(key);
     const std::string value =

--- a/source/ncio/core/NCIO.h
+++ b/source/ncio/core/NCIO.h
@@ -28,6 +28,12 @@ public:
     ~NCIO() = default;
 
     /**
+     * Get configuration file name passed in constructor
+     * @return configuration file name
+     */
+    std::string GetConfigFile() const noexcept;
+
+    /**
      * Set a specific configuration parameter, meant to be equivalent to values
      * in constructor's configFile Using small string optimization SSO (passing
      * by value) as parameters are expected to be small strings. If key exists
@@ -42,7 +48,7 @@ public:
      * @param key input parameter key to search in existing set parameters.
      * @return parameter value, if key not found returns an empty string.
      */
-    std::string GetParameter(const std::string key) noexcept;
+    std::string GetParameter(const std::string key) const noexcept;
 
 private:
     /** input config file passed at constructor */

--- a/source/ncio/core/NCIO.h
+++ b/source/ncio/core/NCIO.h
@@ -1,0 +1,58 @@
+/**
+ * NCIO.h : private C++17 header to the core::NCIO class
+ *
+ *  Created on: May 8, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace ncio::core
+{
+
+class NCIO
+{
+public:
+    /**
+     * NCIO constructor, it's the starting point of contact within the NCIO
+     * library and an application
+     * @param configFile optional input runtime configuration
+     * TODO config file format (yaml?)
+     */
+    NCIO(const std::string &configFile);
+
+    /** Using RAII for all members */
+    ~NCIO() = default;
+
+    /**
+     * Set a specific configuration parameter, meant to be equivalent to values
+     * in constructor's configFile Using small string optimization SSO (passing
+     * by value) as parameters are expected to be small strings. If key exists
+     * it replaces the current value.
+     * @param key input parameter key
+     * @param value input parameter value
+     */
+    void SetParameter(const std::string key, const std::string value) noexcept;
+
+    /**
+     * Returns the value of a parameter found by key.
+     * @param key input parameter key to search in existing set parameters.
+     * @return parameter value, if key not found returns an empty string.
+     */
+    std::string GetParameter(const std::string key) noexcept;
+
+private:
+    /** input config file passed at constructor */
+    const std::string m_ConfigFile;
+
+    /**
+     * Parameter key/value container
+     * interact through SetParameter/GetParameter
+     */
+    std::map<std::string, std::string> m_Parameters;
+};
+
+} // end namespace ncio

--- a/source/ncio/meson.build
+++ b/source/ncio/meson.build
@@ -1,0 +1,18 @@
+
+
+ncio_src = ['core/NCIO.cpp']
+ncio_inc = include_directories(['common','core'])
+
+ncio_lib = library('ncio', 
+                   sources: ncio_src,
+                   include_directories: ncio_inc,
+                   install: true)
+
+# creating a dependency to make it easy to integrate
+# using '../' as headers are included from the ncio prefix
+ncio_dep = declare_dependency( link_with: ncio_lib, 
+                               include_directories: ['../'] )
+
+# -> include/ncio/common/header.h
+install_headers('common/ncioTypes.h', subdir : 'ncio/common') 
+install_headers('common/ncioTypesNexus.h', subdir: 'ncio/common')

--- a/subprojects/doctest.wrap
+++ b/subprojects/doctest.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/onqtam/doctest.git
+revision = 2.3.6
+depth = 1

--- a/testing/meson.build
+++ b/testing/meson.build
@@ -1,0 +1,6 @@
+
+# to find the common ncio-doctest.h 
+ncio_doctest_inc = include_directories('.')
+
+subdir('unit')
+# TODO subdir('functional')

--- a/testing/ncio-doctest.h
+++ b/testing/ncio-doctest.h
@@ -1,0 +1,18 @@
+/*
+ * ncio-doctest.h : common interface header, wrapper around doctest.h header to
+ * add #define to all tests
+ *
+ *  Created on: May 11, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+// Here we can add global #define options to doctest. For documentation see:
+// https://github.com/onqtam/doctest/blob/master/doc/markdown/configuration.md
+#define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#define DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_DISABLE
+
+#include <doctest.h>

--- a/testing/ncio-doctest.h
+++ b/testing/ncio-doctest.h
@@ -10,9 +10,6 @@
 
 // Here we can add global #define options to doctest. For documentation see:
 // https://github.com/onqtam/doctest/blob/master/doc/markdown/configuration.md
-#define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-#define DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#define DOCTEST_CONFIG_DISABLE
 
 #include <doctest.h>

--- a/testing/unit/meson.build
+++ b/testing/unit/meson.build
@@ -1,0 +1,13 @@
+# MESON unit tests executables
+#  Created on: May 11, 2020
+#      Author: William F Godoy godoywf@ornl.gov
+
+unit_tests = ['unitNCIO.cpp']
+
+foreach unit_test : unit_tests
+  exe = executable('unittest-ncio-core-NCIO', 
+                   'ncio/core/' + unit_test,
+                   include_directories:  ncio_doctest_inc, 
+                   dependencies: [ncio_dep, doctest_dep])
+  test(unit_test, exe, timeout: 10)
+endforeach

--- a/testing/unit/ncio/core/unitNCIO.cpp
+++ b/testing/unit/ncio/core/unitNCIO.cpp
@@ -12,7 +12,7 @@
 
 TEST_CASE("Unit test for core::NCIO class")
 {
-    ncio::core::NCIO ncio;
+    ncio::core::NCIO ncio("");
     ncio.SetParameter("key", "value");
     SUBCASE("GetParameter") { REQUIRE(ncio.GetParameter("key") == "value"); }
     SUBCASE("GetConfigFile") { CHECK(ncio.m_ConfigFile == ""); }

--- a/testing/unit/ncio/core/unitNCIO.cpp
+++ b/testing/unit/ncio/core/unitNCIO.cpp
@@ -1,0 +1,19 @@
+/**
+ * unitNCIO.cpp : unit tests for the core::NCIO class using the doctest
+ * framework
+ *
+ *  Created on: May 11, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#include "ncio-doctest.h"
+
+#include "ncio/core/NCIO.h"
+
+TEST_CASE("Unit test for core::NCIO class")
+{
+    ncio::core::NCIO ncio;
+    ncio.SetParameter("key", "value");
+    SUBCASE("GetParameter") { REQUIRE(ncio.GetParameter("key") == "value"); }
+    SUBCASE("GetConfigFile") { CHECK(ncio.m_ConfigFile == ""); }
+}

--- a/testing/unit/ncio/core/unitNCIO.cpp
+++ b/testing/unit/ncio/core/unitNCIO.cpp
@@ -8,12 +8,14 @@
 
 #include "ncio-doctest.h"
 
+#include <iostream>
+
 #include "ncio/core/NCIO.h"
 
 TEST_CASE("Unit test for core::NCIO class")
 {
     ncio::core::NCIO ncio("");
     ncio.SetParameter("key", "value");
-    SUBCASE("GetParameter") { REQUIRE(ncio.GetParameter("key") == "value"); }
-    SUBCASE("GetConfigFile") { CHECK(ncio.m_ConfigFile == ""); }
+    SUBCASE("GetParameter") { CHECK(ncio.GetParameter("key") == "value"); }
+    SUBCASE("GetConfigFile") { CHECK(ncio.GetConfigFile() == ""); }
 }


### PR DESCRIPTION
Initial functional "playground" to understand design trade-off options.
This PR enables us to build, install, and run initial tests on GitHub Actions.

Provides:
Generic Directory structure
Generic `NCIO` class: constructor, parameter getter and setter
Separate private library interfaces from public bindings
Build system: [Meson](https://github.com/mesonbuild/meson) ninja-based build system
Testing Framework: [doctest](https://github.com/onqtam/doctest) lightweight C++ testing framework
README for build, install and test instructions

~If the above if all cool I can start adding CI on GitHub Actions or Azure Pipelines.~
Added CI on GitHub Actions for Ubuntu 18, CentOS 7 and macOS 10.25 (macos-latest)
Addressing #5 