### PR TITLE
CI code coverage codecov report

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -142,7 +142,8 @@ jobs:
           clang-asan, # address sanitizer
           clang-ubsan, # undefined behavior sanitizer
           clang-tsan,  # thread race sanitizer (expensive)
-          clang-msan   # unintialize memory sanitizer (expensive)
+          clang-msan,  # unintialize memory sanitizer (expensive)
+          coverage
         ]
         include:
         - jobname: clang-asan
@@ -164,6 +165,11 @@ jobs:
           container: 
             image: williamfgc/ncio-ci:ubuntu18-gcc8-clang6
             options: -u root
+        
+        - jobname: coverage
+          container: 
+            image: williamfgc/ncio-ci:ubuntu18-gcc8-clang6
+            options: -u root
     
     steps:
     - name: Checkout Action
@@ -177,7 +183,19 @@ jobs:
 
     - name: Test
       run: scripts/ci/github-actions/bash/run_step.sh test
-
+    
+    - name: Coverage
+      if: contains(matrix.jobname, 'coverage')
+      run: scripts/ci/github-actions/bash/run_step.sh coverage
+    
+    - name: Upload Coverage
+      if: contains(matrix.jobname, 'coverage')
+      uses: codecov/codecov-action@v1
+      with:
+        file:  ../ncio-build/meson-logs/coverage.xml 
+        flags: alltests # optional
+        name: codecov-ncio # optional
+        fail_ci_if_error: true # optional (default = false)
 
   static:
     runs-on: ubuntu-latest

--- a/scripts/ci/github-actions/bash/run_step.sh
+++ b/scripts/ci/github-actions/bash/run_step.sh
@@ -33,6 +33,11 @@ case "$1" in
         echo 'Configure for unintialized memory sanitizer msan'
         CC=clang CXX=clang++ meson -Db_lundef=false -Db_sanitize=memory --prefix=${GITHUB_WORKSPACE}/../ncio-install ${GITHUB_WORKSPACE}
       ;;
+      *"coverage"*)
+        echo 'Configure for code coverage'
+        apt-get install gcovr curl -y
+        meson -Db_coverage=true --prefix=${GITHUB_WORKSPACE}/../ncio-install ${GITHUB_WORKSPACE}
+      ;;
       # Test with clang compilers
       *"clang"*)
         echo 'Configure for clang compilers'
@@ -64,7 +69,13 @@ case "$1" in
     cd ${GITHUB_WORKSPACE}/../ncio-build
     ninja test
     ;;
-
+  
+  # Generate coverage reports
+  coverage)
+    cd ${GITHUB_WORKSPACE}/../ncio-build
+    ninja coverage
+    ;;
+    
   *)
     echo " Invalid step" "$1"
     exit -1


### PR DESCRIPTION
Using GitHub actions and `ninja coverage` target from meson `-Db_coverage=true` using tests.