### PR TITLE
Initial single-thread value write read from hdf5 backend

### DIFF
--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.cpp
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.cpp
@@ -53,7 +53,7 @@ void DataDescriptor::CheckImpl(const std::string &functionName)
             "ncio ERROR: invalid DataDescriptor object in call to " +
             functionName +
             ". Please modify your code and pass a valid DataDescriptor created "
-            "with NCIO::Open\n");
+            "with NCIO::Open that has not been previously closed\n");
     }
 }
 

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.cpp
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.cpp
@@ -37,6 +37,14 @@ std::future<void> DataDescriptor::ExecuteAsync(const std::launch mode,
     return m_ImplDataDescriptor->ExecuteAsync(mode, threadID);
 }
 
+void DataDescriptor::Close()
+{
+    CheckImpl("Close");
+    m_ImplDataDescriptor->Close();
+    m_ImplDataDescriptor = nullptr;
+}
+
+// PRIVATE
 void DataDescriptor::CheckImpl(const std::string &functionName)
 {
     if (!*this)

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
@@ -108,6 +108,12 @@ public:
     std::future<void> ExecuteAsync(const std::launch mode,
                                    const int threadID = 0);
 
+    /**
+     * Close all operations with the current DataDescriptor. After this
+     * operation any call becomes invalid.
+     */
+    void Close();
+
 private:
     /**
      * Constructor only allowed for factory friend class NCIO

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project('ncio',
         license: 'BSD 3-Clause',
         version: '0.0.1',
         meson_version: '>=0.52.0',
-        default_options: ['cpp_std=c++17', 'buildtype=release', 'layout=flat']
+        default_options: ['cpp_std=c++17', 'buildtype=debug', 'layout=flat']
 )
 
 # SCHEMAS

--- a/scripts/ci/github-actions/bash/run_step.sh
+++ b/scripts/ci/github-actions/bash/run_step.sh
@@ -45,8 +45,9 @@ case "$1" in
       ;;
       *"coverage"*)
         echo 'Configure for code coverage'
+        # meson regression bug in > 0.55 using 0.54.2
         pip3 install meson==0.54.2
-        meson -Dbuildtype=debugoptimized -Db_coverage=true --prefix=${GITHUB_WORKSPACE}/../ncio-install ${GITHUB_WORKSPACE}
+        meson -Dbuildtype=debug -Db_coverage=true --prefix=${GITHUB_WORKSPACE}/../ncio-install ${GITHUB_WORKSPACE}
       ;;
       # Test with clang compilers
       *"clang"*)

--- a/source/ncio/core/DataDescriptor.cpp
+++ b/source/ncio/core/DataDescriptor.cpp
@@ -115,6 +115,8 @@ std::future<void> DataDescriptor::ExecuteAsync(const std::launch launchMode,
     return std::async(launchMode, &DataDescriptor::Execute, this, threadID);
 }
 
+void DataDescriptor::Close() { m_Transport->Close(); }
+
 std::any DataDescriptor::GetNativeHandler() noexcept
 {
     return m_Transport->GetNativeHandler();

--- a/source/ncio/core/DataDescriptor.h
+++ b/source/ncio/core/DataDescriptor.h
@@ -62,6 +62,9 @@ public:
     std::future<void> ExecuteAsync(const std::launch launchMode,
                                    const int threadID);
 
+    /** Close all operations with the current DataDescriptor */
+    void Close();
+
     /**
      * Get underlying IO handler. This is for advanced users that wan't access
      * to the underlying technology.

--- a/source/ncio/core/DataDescriptor.h
+++ b/source/ncio/core/DataDescriptor.h
@@ -81,7 +81,13 @@ public:
      * @return string registered in a schema from enum defining entries
      */
     template <class Enum, Enum enumValue>
-    std::string ToString() noexcept;
+    std::string ToString() const noexcept;
+
+    /** true: is currently opened, false: is closed and can be re-opened */
+    bool IsOpen() const noexcept;
+
+    /** used by NCIO factory, set open status if reopened */
+    void SetOpenStatus(const bool openStatus) noexcept;
 
 private:
     /**
@@ -98,6 +104,9 @@ private:
     /** Polymorphic object to interact with different I/O library backends.
      * TODO: this would be a container in the future. For now it's 1-to-1. */
     std::unique_ptr<transport::Transport> m_Transport;
+
+    /** true: active, false: Close has been called */
+    bool m_IsOpen;
 
     /**
      * Defines Entry requests for Put and Get.

--- a/source/ncio/core/NCIO.cpp
+++ b/source/ncio/core/NCIO.cpp
@@ -39,10 +39,30 @@ std::optional<std::string> NCIO::GetParameter(const std::string key) const
 core::DataDescriptor &NCIO::Open(const std::string &name,
                                  const OpenMode openMode)
 {
-    auto pair = m_DataDescriptors.emplace(
-        name,
-        std::make_unique<core::DataDescriptor>(name, openMode, m_Parameters));
-    return *pair.first->second.get();
+    auto itDataDescriptor = m_DataDescriptors.find(name);
+
+    // doesn't exist
+    if (itDataDescriptor == m_DataDescriptors.end())
+    {
+
+        auto pair = m_DataDescriptors.emplace(
+            name, std::make_unique<core::DataDescriptor>(name, openMode,
+                                                         m_Parameters));
+        return *pair.first->second.get();
+    }
+
+    // exist
+    DataDescriptor &dataDescriptor = *itDataDescriptor->second.get();
+    if (dataDescriptor.IsOpen())
+    {
+        throw std::logic_error("ncio ERROR: trying to Open DataDescriptor " +
+                               name +
+                               " more than once is not allowed. Call "
+                               "DataDescriptor::Close() first\n");
+    }
+    dataDescriptor.SetOpenStatus(true);
+
+    return dataDescriptor;
 }
 
 } // end namespace ncio::core

--- a/source/ncio/schema/nexus/DataDescriptorNexus.tcc
+++ b/source/ncio/schema/nexus/DataDescriptorNexus.tcc
@@ -16,8 +16,9 @@ namespace ncio::core
 // Implement DataDescriptor::ToString for Schema entries
 #define NCIO_SCHEMA_NEXUS_TOSTRING(bank, entry)                                \
     template <>                                                                \
-    std::string DataDescriptor::ToString<                                      \
-        schema::nexus::bank, schema::nexus::bank::entry>() noexcept            \
+    std::string DataDescriptor::ToString<schema::nexus::bank,                  \
+                                         schema::nexus::bank::entry>()         \
+        const noexcept                                                         \
     {                                                                          \
         return std::string("/entry/").append(#bank).append("/").append(        \
             #entry);                                                           \

--- a/source/ncio/transport/TransportHDF5.cpp
+++ b/source/ncio/transport/TransportHDF5.cpp
@@ -24,9 +24,10 @@ TransportHDF5::TransportHDF5(const std::string &name, const OpenMode openMode,
     {
     case (OpenMode::read):
     {
-        // allow for multiple handlers
         hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
-        H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+        // multiple handlers is not recommended by HDF5
+        // H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+        // https://support.hdfgroup.org/HDF5/doc/RM/RM_H5F.html#File-Open
         m_File = H5Fopen(name.c_str(), H5F_ACC_RDONLY, fapl);
         if (m_File < 0)
         {

--- a/source/ncio/transport/TransportHDF5.h
+++ b/source/ncio/transport/TransportHDF5.h
@@ -11,6 +11,8 @@
 #include "ncio/common/ncioMacros.h"
 #include "ncio/transport/Transport.h"
 
+#include <hdf5.h>
+
 namespace ncio::transport
 {
 
@@ -27,7 +29,10 @@ private:
      * HDF5 file handler. It could be int (4 bytes) or int64_t (8 bytes)
      * Using std::any to keep HDF5 dependency as a private library to ncio
      */
-    std::any m_File = -1;
+    hid_t m_File = -1;
+
+    /** generated Id for top level group "/" */
+    hid_t m_TopGroupID = -1;
 
     void
     DoGetMetadata(std::map<std::string, std::set<std::string>> &index) final;
@@ -54,8 +59,12 @@ private:
 
     std::any DoGetNativeHandler() noexcept final;
 
-    template <class T, class H5T>
-    H5T GetHDF5Datatype();
+    template <class T>
+    hid_t GetHDF5Datatype();
+
+    template <class T>
+    std::vector<hid_t> CreateDataset(const std::string &entryName,
+                                     hid_t fileSpace);
 };
 
 } // end namespace nexus::io

--- a/source/ncio/transport/TransportHDF5.tcc
+++ b/source/ncio/transport/TransportHDF5.tcc
@@ -109,6 +109,13 @@ template <class T>
 void TransportHDF5::DoGetCommon(const std::string &entryName, T *data,
                                 const Box &box, const int threadID)
 {
+    if (box == BoxValue)
+    {
+        hid_t dataSetID = H5Dopen(m_File, entryName.c_str(), H5P_DEFAULT);
+        hid_t status = H5Dread(dataSetID, GetHDF5Datatype<T>(), H5S_ALL,
+                               H5S_ALL, H5P_DEFAULT, data);
+        H5Dclose(dataSetID);
+    }
 }
 
 } // end namespace ncio::transport

--- a/source/ncio/transport/TransportHDF5.tcc
+++ b/source/ncio/transport/TransportHDF5.tcc
@@ -10,6 +10,8 @@
 
 #include "TransportHDF5.h"
 
+#include "ncio/helper/ncioHelperString.h"
+
 #include <hdf5.h>
 
 namespace ncio::transport
@@ -29,7 +31,7 @@ namespace ncio::transport
 
 #define declare_ncio_types(T, H5T_LE)                                          \
     template <>                                                                \
-    hid_t TransportHDF5::GetHDF5Datatype<T, hid_t>()                           \
+    hid_t TransportHDF5::GetHDF5Datatype<T>()                                  \
     {                                                                          \
         return H5T_LE;                                                         \
     }
@@ -38,21 +40,69 @@ NCIO_HD5Types_MAP(declare_ncio_types)
 #undef declare_ncio_types
 
     template <class T>
-    void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
-                                    const Dimensions &dimensions,
-                                    const int threadID)
+    std::vector<hid_t> TransportHDF5::CreateDataset(
+        const std::string &entryName, hid_t fileSpace)
 {
-    // hid_t datasetID;
-    // hid_t type = GetHDF5Datatype<T, hid_t>();
+    const std::vector<std::string> list = helper::string::Split(entryName);
+    std::vector<hid_t> datasetChain;
 
+    hid_t groupID = m_TopGroupID;
+
+    // create groups recursively
+    if (list.size() > 1)
+    {
+        std::string currentGroup = "";
+        for (std::size_t i = 1; i < list.size() - 1; ++i)
+        {
+            currentGroup = list[i];
+            // if (H5Gget_objinfo(groupID, currentGroup.c_str(), 0, NULL) == 0)
+            if (H5Lexists(groupID, currentGroup.c_str(), H5P_DEFAULT) == 0)
+            {
+                groupID = H5Gcreate2(groupID, currentGroup.c_str(), H5P_DEFAULT,
+                                     H5P_DEFAULT, H5P_DEFAULT);
+            }
+            else
+            {
+                groupID = H5Gopen(groupID, currentGroup.c_str(), H5P_DEFAULT);
+            }
+            datasetChain.push_back(groupID);
+        }
+    }
+
+    // create dataset inside the last group
+    hid_t datasetID = -1;
+    if (H5Lexists(groupID, list.back().c_str(), H5P_DEFAULT) == 0)
+    {
+        datasetID =
+            H5Dcreate(groupID, list.back().c_str(), GetHDF5Datatype<T>(),
+                      fileSpace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    }
+    else
+    {
+        datasetID = H5Dopen(groupID, list.back().c_str(), H5P_DEFAULT);
+    }
+
+    datasetChain.push_back(datasetID);
+
+    return datasetChain;
+}
+
+template <class T>
+void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
+                                const Dimensions &dimensions,
+                                const int threadID)
+{
+    // TODO: check valid entryName for HDF5
     // Single value
     if (dimensions == DimensionsValue)
     {
+        hid_t fileSpace = H5Screate(H5S_SCALAR);
+        const std::vector<hid_t> listIDs =
+            CreateDataset<T>(entryName, fileSpace);
+
+        H5Dwrite(listIDs.back(), GetHDF5Datatype<T>(), H5S_ALL, H5S_ALL,
+                 H5P_DEFAULT, data);
     }
-
-    // space = H5Screate_simple(2, , NULL);
-
-    // int status = H5Dwrite(datasetID, , )
 }
 
 template <class T>

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
@@ -21,9 +21,13 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
     }
     SUBCASE("GetConfigFile") { CHECK(ncio.GetConfigFile() == std::nullopt); }
 
+    // minimal functionality tests
+
+#ifdef NCIO_HAVE_HDF5
     SUBCASE("OpenDataDescriptorWriteHDF5")
     {
-        ncio::DataDescriptor fw = ncio.Open("empty.h5", ncio::OpenMode::write);
+        ncio::DataDescriptor fw =
+            ncio.Open("total_counts.h5", ncio::OpenMode::write);
 
         constexpr float totalCounts = 10;
         fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts);
@@ -33,14 +37,42 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
 
     SUBCASE("OpenDataDescriptorReadHDF5")
     {
-        ncio::DataDescriptor fr = ncio.Open("empty.h5", ncio::OpenMode::read);
+        ncio::DataDescriptor fr =
+            ncio.Open("total_counts.h5", ncio::OpenMode::read);
+
         float totalCounts = 0;
         fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
         fr.Execute();
         fr.Close();
+
+        CHECK_EQ(totalCounts, 10);
+    }
+
+    SUBCASE("OpenExceptions")
+    {
+        ncio.Open("total_counts.h5", ncio::OpenMode::read);
+        CHECK_THROWS_WITH_AS(
+            ncio.Open("total_counts.h5", ncio::OpenMode::read),
+            "ncio ERROR: trying to Open DataDescriptor total_counts.h5 more "
+            "than once is not allowed. Call DataDescriptor::Close() first\n",
+            std::logic_error);
+    }
+
+    SUBCASE("CloseExceptions")
+    {
+        ncio::DataDescriptor fr =
+            ncio.Open("total_counts.h5", ncio::OpenMode::read);
+        fr.Close();
+        CHECK_THROWS_WITH_AS(
+            fr.Close(),
+            "ncio ERROR: invalid DataDescriptor object in call to Close. "
+            "Please modify your code and pass a valid DataDescriptor created "
+            "with NCIO::Open that has not been previously closed\n",
+            std::logic_error);
     }
 
     ncio.SetParameter("Transport", "Null");
+#endif
 
     SUBCASE("OpenDataDescriptorWriteNull")
     {
@@ -59,5 +91,15 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
         fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
         fr.Execute();
         fr.Close();
+    }
+
+    ncio.SetParameter("Transport", "Unsupported");
+    SUBCASE("UnsupportedTransport")
+    {
+        CHECK_THROWS_WITH_AS(
+            ncio.Open("null", ncio::OpenMode::read),
+            "ncio ERROR: for parameters key=transport value=Unsupported is not "
+            "valid. Only hdf5 and null are supported\n",
+            std::invalid_argument);
     }
 }

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
@@ -28,14 +28,16 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
         constexpr float totalCounts = 10;
         fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts);
         fw.Execute();
+        fw.Close();
     }
 
     SUBCASE("OpenDataDescriptorReadHDF5")
     {
-        ncio::DataDescriptor fh = ncio.Open("empty.h5", ncio::OpenMode::read);
+        ncio::DataDescriptor fr = ncio.Open("empty.h5", ncio::OpenMode::read);
         float totalCounts = 0;
-        fh.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
-        fh.Execute();
+        fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
+        fr.Execute();
+        fr.Close();
     }
 
     ncio.SetParameter("Transport", "Null");
@@ -47,6 +49,7 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
         constexpr float dataI32 = 10;
         fh.Put<ncio::schema::nexus::bank1::total_counts>(dataI32);
         fh.Execute();
+        fh.Close();
     }
 
     SUBCASE("OpenDataDescriptorReadNull")
@@ -55,5 +58,6 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
         float totalCounts = 0.;
         fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
         fr.Execute();
+        fr.Close();
     }
 }


### PR DESCRIPTION
Only allow one `DataDescriptor` handler at a time. Recommended by HDF5.
Add tests to increase code coverage.
Remove dead code.
Move HDF5 definitions to private Transport.h header in `libncio.so`