### PR TITLE
Enable thread-safe write read APIs using hdf5 backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 *.dll
 *.obj
 build/
+*.h5
 
 # Mac OSX finder-related files
 .DS_Store

--- a/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
+++ b/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
@@ -18,10 +18,10 @@ namespace ncio
     template void DataDescriptor::Put<schema::nexus::bank##T::event_id>(       \
         const std::uint64_t &, const int);                                     \
     template void DataDescriptor::Put<schema::nexus::bank##T::event_index>(    \
-        const std::uint32_t &, const int);                                     \
+        const std::uint64_t *, const Dimensions &, const int);                 \
     template void                                                              \
     DataDescriptor::Put<schema::nexus::bank##T::event_time_offset>(            \
-        const float &, const int);                                             \
+        const float *, const Dimensions &, const int);                         \
     template void                                                              \
     DataDescriptor::Put<schema::nexus::bank##T::event_time_zero>(              \
         const double &, const int);                                            \
@@ -35,10 +35,12 @@ NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
     template void DataDescriptor::Get<schema::nexus::bank##T::event_id>(       \
         std::uint64_t &, const int);                                           \
     template void DataDescriptor::Get<schema::nexus::bank##T::event_index>(    \
-        std::uint32_t &, const int);                                           \
+        std::uint64_t *, const Box &box, const int);                           \
+                                                                               \
     template void                                                              \
-    DataDescriptor::Get<schema::nexus::bank##T::event_time_offset>(float &,    \
-                                                                   const int); \
+    DataDescriptor::Get<schema::nexus::bank##T::event_time_offset>(            \
+        float *, const Box &box, const int);                                   \
+                                                                               \
     template void                                                              \
     DataDescriptor::Get<schema::nexus::bank##T::event_time_zero>(double &,     \
                                                                  const int);   \

--- a/scripts/ci/github-actions/bash/run_step.sh
+++ b/scripts/ci/github-actions/bash/run_step.sh
@@ -78,7 +78,7 @@ case "$1" in
   # Install the library
   install)
     cd ${GITHUB_WORKSPACE}/../ncio-build
-    ninja test
+    ninja install
     ;;
   
   # Generate coverage reports

--- a/source/ncio/core/DataDescriptor.h
+++ b/source/ncio/core/DataDescriptor.h
@@ -156,7 +156,7 @@ private:
                        const OpenMode openMode, const Parameters &parameters);
 
     /**
-     * Put entry into m_Transport->Put
+     * Put entry into m_Transport->Put. Called at Execute for writing.
      * @tparam T
      * @param entryName
      * @param entry
@@ -164,7 +164,18 @@ private:
      */
     template <class T>
     void PutEntry(const std::string &entryName, const Entry &entry,
-                  const int thread);
+                  const int threadID);
+
+    /**
+     * Get entry into m_Transport->Put. Called at Execute for reading.
+     * @tparam T
+     * @param entryName
+     * @param entry
+     * @param thread
+     */
+    template <class T>
+    void GetEntry(const std::string &entryName, Entry &entry,
+                  const int threadID);
 };
 
 } // end namespace ncio::core

--- a/source/ncio/core/DataDescriptor.tcc
+++ b/source/ncio/core/DataDescriptor.tcc
@@ -82,15 +82,21 @@ void DataDescriptor::PutEntry(const std::string &entryName, const Entry &entry,
     case (ShapeType::value):
     {
         const T *data = std::any_cast<const T>(&entry.data);
-        m_Transport->Put(entryName, data, DimensionsValue, threadID);
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        {
+            m_Transport->Put(entryName, data, DimensionsValue, threadID);
+        }
         break;
     }
     case (ShapeType::array):
     {
         // TODO some checks on Dimensions
         const T *data = std::any_cast<const T *>(entry.data);
-        m_Transport->Put(entryName, data, std::get<Dimensions>(entry.query),
-                         threadID);
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        {
+            m_Transport->Put(entryName, data, std::get<Dimensions>(entry.query),
+                             threadID);
+        }
         break;
     }
     }
@@ -105,14 +111,21 @@ void DataDescriptor::GetEntry(const std::string &entryName, Entry &entry,
     case (ShapeType::value):
     {
         T *data = std::any_cast<T>(&entry.data);
-        m_Transport->Get(entryName, data, DimensionsValue, threadID);
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        {
+            m_Transport->Get(entryName, data, DimensionsValue, threadID);
+        }
         break;
     }
     case (ShapeType::array):
     {
         // TODO some checks on Dimensions
         T *data = std::any_cast<T *>(entry.data);
-        m_Transport->Get(entryName, data, std::get<Box>(entry.query), threadID);
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        {
+            m_Transport->Get(entryName, data, std::get<Box>(entry.query),
+                             threadID);
+        }
         break;
     }
     }

--- a/source/ncio/core/DataDescriptor.tcc
+++ b/source/ncio/core/DataDescriptor.tcc
@@ -87,9 +87,32 @@ void DataDescriptor::PutEntry(const std::string &entryName, const Entry &entry,
     }
     case (ShapeType::array):
     {
+        // TODO some checks on Dimensions
         const T *data = std::any_cast<const T *>(entry.data);
         m_Transport->Put(entryName, data, std::get<Dimensions>(entry.query),
                          threadID);
+        break;
+    }
+    }
+}
+
+template <class T>
+void DataDescriptor::GetEntry(const std::string &entryName, Entry &entry,
+                              const int threadID)
+{
+    switch (entry.shapeType)
+    {
+    case (ShapeType::value):
+    {
+        T *data = std::any_cast<T>(&entry.data);
+        m_Transport->Get(entryName, data, DimensionsValue, threadID);
+        break;
+    }
+    case (ShapeType::array):
+    {
+        // TODO some checks on Dimensions
+        T *data = std::any_cast<T *>(entry.data);
+        m_Transport->Get(entryName, data, std::get<Box>(entry.query), threadID);
         break;
     }
     }

--- a/source/ncio/transport/TransportHDF5.cpp
+++ b/source/ncio/transport/TransportHDF5.cpp
@@ -99,8 +99,8 @@ void TransportHDF5::DoClose()
     const herr_t status = H5Fclose(m_File);
     if (status < 0)
     {
-        throw std::invalid_argument("ncio ERROR: couldn't close HDF5 file " +
-                                    m_Name + "\n");
+        throw std::runtime_error("ncio ERROR: couldn't close HDF5 file " +
+                                 m_Name + "\n");
     }
     m_IsOpen = false;
 }

--- a/source/ncio/transport/TransportHDF5.h
+++ b/source/ncio/transport/TransportHDF5.h
@@ -65,6 +65,8 @@ private:
     template <class T>
     std::vector<hid_t> CreateDataset(const std::string &entryName,
                                      hid_t fileSpace);
+
+    void CloseDataset(std::vector<hid_t> &handlers);
 };
 
 } // end namespace nexus::io

--- a/source/ncio/transport/TransportHDF5.tcc
+++ b/source/ncio/transport/TransportHDF5.tcc
@@ -55,7 +55,7 @@ NCIO_HD5Types_MAP(declare_ncio_types)
         for (std::size_t i = 1; i < list.size() - 1; ++i)
         {
             currentGroup = list[i];
-            // if (H5Gget_objinfo(groupID, currentGroup.c_str(), 0, NULL) == 0)
+
             if (H5Lexists(groupID, currentGroup.c_str(), H5P_DEFAULT) == 0)
             {
                 groupID = H5Gcreate2(groupID, currentGroup.c_str(), H5P_DEFAULT,
@@ -92,16 +92,68 @@ void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
                                 const Dimensions &dimensions,
                                 const int threadID)
 {
+    auto lf_H5SCreateSimple =
+        [](const std::vector<std::size_t> &input) -> hid_t {
+        return H5Screate_simple(static_cast<int>(input.size()),
+                                reinterpret_cast<hsize_t *>(
+                                    const_cast<std::size_t *>(input.data())),
+                                NULL);
+    };
+
     // TODO: check valid entryName for HDF5
-    // Single value
+    // single value (aka scalar)
     if (dimensions == DimensionsValue)
     {
         hid_t fileSpace = H5Screate(H5S_SCALAR);
         const std::vector<hid_t> listIDs =
             CreateDataset<T>(entryName, fileSpace);
+        hid_t datasetID = listIDs.back();
+        hid_t status = H5Dwrite(datasetID, GetHDF5Datatype<T>(), H5S_ALL,
+                                H5S_ALL, H5P_DEFAULT, data);
+        // TODO capture status
+        if (status < 0)
+        {
+            throw std::runtime_error("ncio ERROR: couldn't write entry " +
+                                     entryName + " to HDF5 file " + m_Name +
+                                     "\n");
+        }
+    }
+    // array
+    else
+    {
+        const auto [shape, start, count] = dimensions;
 
-        H5Dwrite(listIDs.back(), GetHDF5Datatype<T>(), H5S_ALL, H5S_ALL,
-                 H5P_DEFAULT, data);
+        // create file space and dataset
+        hid_t fileSpace = lf_H5SCreateSimple(shape);
+        const std::vector<hid_t> listIDs =
+            CreateDataset<T>(entryName, fileSpace);
+
+        // retrieve fileSpace from dataset and set hyperslab box selection
+        hid_t datasetID = listIDs.back();
+        fileSpace = H5Dget_space(datasetID);
+
+        // FIXME address empty count
+        H5Sselect_hyperslab(fileSpace, H5S_SELECT_SET,
+                            reinterpret_cast<hsize_t *>(
+                                const_cast<std::size_t *>(start.data())),
+                            NULL,
+                            reinterpret_cast<hsize_t *>(
+                                const_cast<std::size_t *>(count.data())),
+                            NULL);
+
+        // actual memory space
+        hid_t memorySpace = count.empty() ? lf_H5SCreateSimple(shape)
+                                          : lf_H5SCreateSimple(count);
+        const hid_t status =
+            H5Dwrite(datasetID, GetHDF5Datatype<T>(), memorySpace, fileSpace,
+                     H5P_DEFAULT, data);
+
+        if (status < 0)
+        {
+            throw std::runtime_error("ncio ERROR: couldn't write entry " +
+                                     entryName + " to HDF5 file " + m_Name +
+                                     "\n");
+        }
     }
 }
 
@@ -109,12 +161,50 @@ template <class T>
 void TransportHDF5::DoGetCommon(const std::string &entryName, T *data,
                                 const Box &box, const int threadID)
 {
+
+    hid_t dataSetID = H5Dopen(m_File, entryName.c_str(), H5P_DEFAULT);
+    // TODO check dataSetID for errors
+
     if (box == BoxValue)
     {
-        hid_t dataSetID = H5Dopen(m_File, entryName.c_str(), H5P_DEFAULT);
         hid_t status = H5Dread(dataSetID, GetHDF5Datatype<T>(), H5S_ALL,
                                H5S_ALL, H5P_DEFAULT, data);
+        if (status < 0)
+        {
+            throw std::runtime_error("ncio ERROR: couldn't read entry " +
+                                     entryName + " from HDF5 file " + m_Name +
+                                     "\n");
+        }
         H5Dclose(dataSetID);
+    }
+    // array with Box selection
+    else
+    {
+        const auto [start, count] = box;
+        hid_t fileSpace = H5Dget_space(dataSetID); /* dataspace handle */
+
+        H5Sselect_hyperslab(fileSpace, H5S_SELECT_SET,
+                            reinterpret_cast<hsize_t *>(
+                                const_cast<std::size_t *>(start.data())),
+                            NULL,
+                            reinterpret_cast<hsize_t *>(
+                                const_cast<std::size_t *>(count.data())),
+                            NULL);
+
+        // actual memory space
+        hid_t memorySpace =
+            H5Screate_simple(static_cast<int>(count.size()),
+                             reinterpret_cast<hsize_t *>(
+                                 const_cast<std::size_t *>(count.data())),
+                             NULL);
+        hid_t status = H5Dread(dataSetID, GetHDF5Datatype<T>(), memorySpace,
+                               fileSpace, H5P_DEFAULT, data);
+        if (status < 0)
+        {
+            throw std::runtime_error("ncio ERROR: couldn't read array entry " +
+                                     entryName + " from HDF5 file " + m_Name +
+                                     "\n");
+        }
     }
 }
 

--- a/source/ncio/transport/TransportHDF5.tcc
+++ b/source/ncio/transport/TransportHDF5.tcc
@@ -105,8 +105,7 @@ void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
     if (dimensions == DimensionsValue)
     {
         hid_t fileSpace = H5Screate(H5S_SCALAR);
-        const std::vector<hid_t> listIDs =
-            CreateDataset<T>(entryName, fileSpace);
+        std::vector<hid_t> listIDs = CreateDataset<T>(entryName, fileSpace);
         hid_t datasetID = listIDs.back();
         hid_t status = H5Dwrite(datasetID, GetHDF5Datatype<T>(), H5S_ALL,
                                 H5S_ALL, H5P_DEFAULT, data);
@@ -117,6 +116,7 @@ void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
                                      entryName + " to HDF5 file " + m_Name +
                                      "\n");
         }
+        CloseDataset(listIDs);
     }
     // array
     else
@@ -125,8 +125,7 @@ void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
 
         // create file space and dataset
         hid_t fileSpace = lf_H5SCreateSimple(shape);
-        const std::vector<hid_t> listIDs =
-            CreateDataset<T>(entryName, fileSpace);
+        std::vector<hid_t> listIDs = CreateDataset<T>(entryName, fileSpace);
 
         // retrieve fileSpace from dataset and set hyperslab box selection
         hid_t datasetID = listIDs.back();
@@ -154,6 +153,7 @@ void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
                                      entryName + " to HDF5 file " + m_Name +
                                      "\n");
         }
+        CloseDataset(listIDs);
     }
 }
 

--- a/subprojects/doctest.wrap
+++ b/subprojects/doctest.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/onqtam/doctest.git
-revision = 2.3.6
+revision = 2.4.1
 depth = 1

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
     SUBCASE("ReadHDF5_async")
     {
         float totalCounts = 0;
-        std::array<std::uint64_t, 3> eventIndex;
+        std::vector<std::uint64_t> eventIndex(3);
 
         ncio::DataDescriptor fr =
             ncio.Open("data_async.h5", ncio::OpenMode::read);
@@ -68,7 +68,7 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
         fr.Close();
 
         CHECK_EQ(totalCounts, 10);
-        CHECK_EQ(eventIndex, std::array<std::uint64_t, 3>{1, 2, 3});
+        CHECK_EQ(eventIndex, std::vector<std::uint64_t>{1, 2, 3});
     }
 
     SUBCASE("WriteHDF5_threads")

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
@@ -1,0 +1,55 @@
+/**
+ * functionalTest_cxx17DataDescriptor.cpp : functional tests for the
+ * ncio::DataDescriptor C++17 bindings class using the doctest framework
+ *
+ *  Created on: Dec 7, 2020
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#include "ncio-doctest.h"
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include <ncio.h>
+
+TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
+{
+    ncio::NCIO ncio;
+
+    std::future<void> future;
+    // minimal functionality tests for DataDescriptor, more in
+    // functionalTest_cxx17DataDescriptor.cpp
+#ifdef NCIO_HAVE_HDF5
+    SUBCASE("WriteAsyncHDF5")
+    {
+        ncio::DataDescriptor fw =
+            ncio.Open("nexus_async.nxs.h5", ncio::OpenMode::write);
+
+        // put a single value
+        constexpr float totalCounts = 10;
+        fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts);
+
+        // put a 1D array
+        constexpr std::array<std::uint64_t, 3> eventIndex = {1, 2, 3};
+        constexpr std::size_t nx = eventIndex.size();
+        fw.Put<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
+                                                        {{nx}, {0}, {nx}});
+
+        constexpr std::array<float, 3> eventTimeOffset = {1.f, 2.f, 3.f};
+        fw.Put<ncio::schema::nexus::bank1::event_time_offset>(
+            eventTimeOffset.data(), {{nx}, {0}, {nx}});
+        // launch in a separate thread
+        future = fw.ExecuteAsync(std::launch::async);
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        // wait until done
+        future.get();
+
+        fw.Close();
+    }
+
+#endif
+}

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
@@ -10,45 +10,188 @@
 
 #include <chrono>
 #include <future>
+#include <numeric> // std::iota
 #include <thread>
 
 #include <ncio.h>
 
-TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
+TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
 {
     ncio::NCIO ncio;
+    ncio.SetParameter("Transport", "HDF5");
 
-    std::future<void> future;
-    // minimal functionality tests for DataDescriptor, more in
-    // functionalTest_cxx17DataDescriptor.cpp
 #ifdef NCIO_HAVE_HDF5
-    SUBCASE("WriteAsyncHDF5")
+    SUBCASE("WriteHDF5_async")
     {
         ncio::DataDescriptor fw =
-            ncio.Open("nexus_async.nxs.h5", ncio::OpenMode::write);
+            ncio.Open("data_async.h5", ncio::OpenMode::write);
 
         // put a single value
         constexpr float totalCounts = 10;
         fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts);
 
         // put a 1D array
-        constexpr std::array<std::uint64_t, 3> eventIndex = {1, 2, 3};
-        constexpr std::size_t nx = eventIndex.size();
+        const std::vector<std::uint64_t> eventIndex = {1, 2, 3};
+        const std::size_t nx = eventIndex.size();
         fw.Put<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
                                                         {{nx}, {0}, {nx}});
 
-        constexpr std::array<float, 3> eventTimeOffset = {1.f, 2.f, 3.f};
+        const std::vector<float> eventTimeOffset = {1.f, 2.f, 3.f};
         fw.Put<ncio::schema::nexus::bank1::event_time_offset>(
             eventTimeOffset.data(), {{nx}, {0}, {nx}});
-        // launch in a separate thread
-        future = fw.ExecuteAsync(std::launch::async);
-
+        // launch in a separate thread and wait
+        std::future future = fw.ExecuteAsync(std::launch::async);
         std::this_thread::sleep_for(std::chrono::seconds(1));
 
-        // wait until done
         future.get();
 
         fw.Close();
+    }
+
+    SUBCASE("ReadHDF5_async")
+    {
+        float totalCounts = 0;
+        std::array<std::uint64_t, 3> eventIndex;
+
+        ncio::DataDescriptor fr =
+            ncio.Open("data_async.h5", ncio::OpenMode::read);
+
+        fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
+        fr.Get<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
+                                                        ncio::BoxAll);
+
+        std::future future = fr.ExecuteAsync(std::launch::async);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        future.get();
+
+        fr.Close();
+
+        CHECK_EQ(totalCounts, 10);
+        CHECK_EQ(eventIndex, std::array<std::uint64_t, 3>{1, 2, 3});
+    }
+
+    SUBCASE("WriteHDF5_threads")
+    {
+        // function that writes a section of the array from a thread
+        auto lf_WriteThread = [](const std::size_t threadID,
+                                 const std::size_t nThreads,
+                                 std::vector<float> &eventTimeOffset,
+                                 ncio::DataDescriptor &fw) {
+            // last
+            const std::size_t shape = eventTimeOffset.size();
+            const std::size_t start = (shape / nThreads) * threadID;
+            const std::size_t count = (threadID == nThreads - 1)
+                                          ? shape / nThreads + shape % nThreads
+                                          : shape / nThreads;
+
+            std::iota(eventTimeOffset.begin() + start,
+                      eventTimeOffset.begin() + start + count,
+                      static_cast<float>(start));
+
+            // array sections
+            fw.Put<ncio::schema::nexus::bank1::event_time_offset>(
+                &eventTimeOffset[start], {{shape}, {start}, {count}}, threadID);
+
+            // single value from only one thread
+            if (threadID == 0)
+            {
+                constexpr float totalCounts = 10;
+                fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts,
+                                                                 0);
+            }
+
+            fw.Execute(threadID);
+        };
+
+        std::vector<float> eventTimeOffset(1024);
+
+        ncio::DataDescriptor fw =
+            ncio.Open("data_threads.h5", ncio::OpenMode::write);
+
+        // maximum number of threads
+        const std::size_t nThreads =
+            static_cast<std::size_t>(std::thread::hardware_concurrency());
+
+        std::vector<std::thread> threads;
+        threads.reserve(nThreads);
+
+        for (std::size_t threadID = 0; threadID < nThreads; ++threadID)
+        {
+            threads.emplace_back(lf_WriteThread, threadID, nThreads,
+                                 std::ref(eventTimeOffset), std::ref(fw));
+        }
+
+        for (auto &thread : threads)
+        {
+            thread.join();
+        }
+
+        fw.Close();
+    }
+
+    SUBCASE("ReadHDF5_threads")
+    {
+        // function that writes a section of the array from a thread
+        auto lf_ReadThread = [](const std::size_t threadID,
+                                const std::size_t nThreads,
+                                std::vector<float> &eventTimeOffset,
+                                float &totalCounts, ncio::DataDescriptor &fw) {
+            // last
+            const std::size_t shape = eventTimeOffset.size();
+            const std::size_t start = (shape / nThreads) * threadID;
+            const std::size_t count = (threadID == nThreads - 1)
+                                          ? shape / nThreads + shape % nThreads
+                                          : shape / nThreads;
+
+            // array sections
+            fw.Get<ncio::schema::nexus::bank1::event_time_offset>(
+                &eventTimeOffset[start], {{start}, {count}}, threadID);
+
+            // single value from only one thread
+            if (threadID == 0)
+            {
+                fw.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts,
+                                                                 0);
+            }
+
+            fw.Execute(threadID);
+        };
+
+        std::vector<float> eventTimeOffsetExpected(1024);
+        std::iota(eventTimeOffsetExpected.begin(),
+                  eventTimeOffsetExpected.end(), 0.f);
+        constexpr float totalCountsExpected = 10.f;
+
+        std::vector<float> eventTimeOffset(1024);
+        float totalCounts = 0.f;
+
+        ncio::DataDescriptor fw =
+            ncio.Open("data_threads.h5", ncio::OpenMode::read);
+
+        // maximum number of threads
+        const std::size_t nThreads =
+            static_cast<std::size_t>(std::thread::hardware_concurrency());
+
+        std::vector<std::thread> threads;
+        threads.reserve(nThreads);
+
+        for (std::size_t threadID = 0; threadID < nThreads; ++threadID)
+        {
+            threads.emplace_back(lf_ReadThread, threadID, nThreads,
+                                 std::ref(eventTimeOffset),
+                                 std::ref(totalCounts), std::ref(fw));
+        }
+
+        for (auto &thread : threads)
+        {
+            thread.join();
+        }
+
+        fw.Close();
+
+        CHECK_EQ(eventTimeOffset, eventTimeOffsetExpected);
+        CHECK_EQ(totalCounts, totalCountsExpected);
     }
 
 #endif

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
             eventTimeOffset.data(), {{nx}, {0}, {nx}});
         // launch in a separate thread and wait
         std::future future = fw.ExecuteAsync(std::launch::async);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        // std::this_thread::sleep_for(std::chrono::seconds(1));
 
         future.get();
 
@@ -61,7 +61,7 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
                                                         ncio::BoxAll);
 
         std::future future = fr.ExecuteAsync(std::launch::async);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        // std::this_thread::sleep_for(std::chrono::seconds(1));
 
         future.get();
 
@@ -111,7 +111,12 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
 
         // maximum number of threads
         const std::size_t nThreads =
-            static_cast<std::size_t>(std::thread::hardware_concurrency());
+#ifdef __APPLE__
+            1;
+#else
+            static_cast<std::size_t>(std::thread::hardware_concurrency() / 2);
+#endif
+        std::cout << "nThreads writers = " << nThreads << "\n";
 
         std::vector<std::thread> threads;
         threads.reserve(nThreads);
@@ -169,9 +174,14 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
         ncio::DataDescriptor fw =
             ncio.Open("data_threads.h5", ncio::OpenMode::read);
 
-        // maximum number of threads
         const std::size_t nThreads =
-            static_cast<std::size_t>(std::thread::hardware_concurrency());
+#ifdef __APPLE__
+            1;
+#else
+            static_cast<std::size_t>(std::thread::hardware_concurrency() / 2);
+#endif
+
+        std::cout << "nThreads readers = " << nThreads << "\n";
 
         std::vector<std::thread> threads;
         threads.reserve(nThreads);

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
@@ -1,6 +1,6 @@
 /**
- * testNCIO.cpp : unit tests for the ncio::NCIO C++17 bindings class using the
- * doctest framework
+ * functionalTest_cxx17NCIO.cpp : functional tests for the ncio::NCIO C++17
+ * bindings class using the doctest framework
  *
  *  Created on: May 18, 2020
  *      Author: William F Godoy godoywf@ornl.gov
@@ -10,7 +10,7 @@
 
 #include <ncio.h>
 
-TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
+TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
 {
     ncio::NCIO ncio;
     ncio.SetParameter("key", "value");
@@ -21,7 +21,8 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
     }
     SUBCASE("GetConfigFile") { CHECK(ncio.GetConfigFile() == std::nullopt); }
 
-    // minimal functionality tests
+    // minimal functionality tests for DataDescriptor, more in
+    // functionalTest_cxx17DataDescriptor.cpp
 
 #ifdef NCIO_HAVE_HDF5
     SUBCASE("OpenDataDescriptorWriteHDF5")
@@ -29,23 +30,35 @@ TEST_CASE("Function test for ncio::NCIO C++17 bindings class")
         ncio::DataDescriptor fw =
             ncio.Open("total_counts.h5", ncio::OpenMode::write);
 
+        // put a single value
         constexpr float totalCounts = 10;
         fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts);
+
+        // put a 1D array
+        constexpr std::array<std::uint64_t, 3> eventIndex = {1, 2, 3};
+        constexpr std::size_t nx = eventIndex.size();
+        fw.Put<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
+                                                        {{nx}, {0}, {nx}});
         fw.Execute();
         fw.Close();
     }
 
     SUBCASE("OpenDataDescriptorReadHDF5")
     {
+        float totalCounts = 0;
+        std::array<std::uint64_t, 3> eventIndex;
+
         ncio::DataDescriptor fr =
             ncio.Open("total_counts.h5", ncio::OpenMode::read);
 
-        float totalCounts = 0;
         fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
+        fr.Get<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
+                                                        ncio::BoxAll);
         fr.Execute();
         fr.Close();
 
         CHECK_EQ(totalCounts, 10);
+        CHECK_EQ(eventIndex, std::array<std::uint64_t, 3>{1, 2, 3});
     }
 
     SUBCASE("OpenExceptions")

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
@@ -8,6 +8,10 @@
 
 #include "ncio-doctest.h"
 
+#include <future>
+#include <numeric> // std::iota
+#include <thread>
+
 #include <ncio.h>
 
 TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
@@ -8,6 +8,7 @@
 
 #include "ncio-doctest.h"
 
+#include <array>
 #include <future>
 #include <numeric> // std::iota
 #include <thread>
@@ -39,8 +40,9 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
         fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts);
 
         // put a 1D array
-        constexpr std::array<std::uint64_t, 3> eventIndex = {1, 2, 3};
-        constexpr std::size_t nx = eventIndex.size();
+        // moving from constexpr to const, not allowed by macOS clang in CI
+        const std::array<std::uint64_t, 3> eventIndex = {1, 2, 3};
+        const std::size_t nx = eventIndex.size();
         fw.Put<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
                                                         {{nx}, {0}, {nx}});
         fw.Execute();
@@ -50,7 +52,7 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
     SUBCASE("OpenDataDescriptorReadHDF5")
     {
         float totalCounts = 0;
-        std::array<std::uint64_t, 3> eventIndex;
+        std::vector<std::uint64_t> eventIndex(3);
 
         ncio::DataDescriptor fr =
             ncio.Open("total_counts.h5", ncio::OpenMode::read);
@@ -62,7 +64,7 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
         fr.Close();
 
         CHECK_EQ(totalCounts, 10);
-        CHECK_EQ(eventIndex, std::array<std::uint64_t, 3>{1, 2, 3});
+        CHECK_EQ(eventIndex, std::vector<std::uint64_t>{1, 2, 3});
     }
 
     SUBCASE("OpenExceptions")

--- a/testing/functional/bindings/CXX17/meson.build
+++ b/testing/functional/bindings/CXX17/meson.build
@@ -3,7 +3,7 @@
 #      Author: William F Godoy godoywf@ornl.gov
 
 
-tests = ['NCIO']
+tests = ['NCIO', 'DataDescriptor']
 
 foreach test : tests
   exe = executable('functionaltest-cxx17-' + test, 

--- a/testing/functional/bindings/CXX17/meson.build
+++ b/testing/functional/bindings/CXX17/meson.build
@@ -9,8 +9,8 @@ foreach test : tests
   exe = executable('functionaltest-cxx17-' + test, 
                    'functionalTest_cxx17' + test + '.cpp',
                    include_directories:  ncio_doctest_inc, 
-                   dependencies: [ncio_cxx17_dep, doctest_dep])
-  test(test, exe, timeout: 10, suite: ['functionaltest', 'cxx17'] )
+                   dependencies: [ncio_cxx17_dep, doctest_dep, threads_dep])
+  test(test, exe, timeout: 10, suite: ['functionaltest', 'cxx17'], is_parallel: false )
 endforeach
 
 
@@ -22,6 +22,6 @@ foreach ncio_schema : ncio_schemas
   exe = executable('functionaltest-cxx17-schema-' + test, 
                    file_name,
                    include_directories:  ncio_doctest_inc, 
-                   dependencies: [ncio_cxx17_dep, doctest_dep])
+                   dependencies: [ncio_cxx17_dep, doctest_dep, threads_dep])
   test( test, exe, timeout: 10, suite: ['functionaltest', 'cxx17', 'schema'])
 endforeach

--- a/testing/ncio-doctest.h
+++ b/testing/ncio-doctest.h
@@ -11,5 +11,6 @@
 // Here we can add global #define options to doctest. For documentation see:
 // https://github.com/onqtam/doctest/blob/master/doc/markdown/configuration.md
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #include <doctest.h>


### PR DESCRIPTION
Enable array sections to be accesses (write and read) from multiple threads safely.
Test using `std::thread`.
Test `ExecuteAsync()`.
Use `H5dont_atexit()` to prevent seg faults.
Add tests for nexus schema and bump coverage.