### PR TITLE
Get in-memory metadata index and write attributes

### DIFF
--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
@@ -44,6 +44,12 @@ public:
      */
     explicit operator bool() const noexcept;
 
+    template <auto attribute, class T>
+    void PutAttribute(const int threadID = 0);
+
+    template <auto entry, class T>
+    void PutAttribute(const T &data, const int threadID = 0);
+
     /**
      * Write prefetch operation.
      * Register data pointer for a particular entry.
@@ -58,7 +64,6 @@ public:
      * - std::invalid_argument:
      *   - if data is nullptr
      */
-
     template <auto entry, class T>
     void Put(const T &data, const int threadID = 0);
 

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
@@ -88,6 +88,16 @@ public:
     void Get(T *data, const Box &box, const int threadID = 0);
 
     /**
+     * GetMetadata provides an application specific in-memory index.
+     * @tparam schema type
+     * @tparam T application specific data structure type for the metadata index
+     * @param parameters
+     * @return expected data structure for metadata index model
+     */
+    template <auto indexModel, class T>
+    T GetMetadata(const Parameters &parameters = Parameters());
+
+    /**
      * Executes system I/O to transfer memory between writing Puts and reading
      * Gets. Expensive function can be wrapped around std::async for running in
      * the background.

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
@@ -55,6 +55,14 @@ void DataDescriptor::Get(T *data, const Box &box, const int threadID)
     m_ImplDataDescriptor->Get(entryName, data, box, threadID);
 }
 
+template <auto indexModel, class T>
+T DataDescriptor::GetMetadata(const Parameters &parameters)
+{
+    CheckImpl("GetMetadata");
+    return m_ImplDataDescriptor
+        ->GetMetadata<decltype(indexModel), indexModel, T>(parameters);
+}
+
 } // end namespace ncio
 
 #ifdef NCIO_HAVE_SCHEMA_NEXUS

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
@@ -18,8 +18,28 @@
 namespace ncio
 {
 
+template <auto attribute, class T>
+void DataDescriptor::PutAttribute(const int threadID)
+{
+    CheckImpl("PutAttribute");
+    const std::string attributeName =
+        m_ImplDataDescriptor->ToString<decltype(attribute), attribute>();
+    const T data = m_ImplDataDescriptor
+                       ->AttributeData<decltype(attribute), attribute, T>();
+    m_ImplDataDescriptor->PutAttribute(attributeName, data, threadID);
+}
+
+template <auto attribute, class T>
+void DataDescriptor::PutAttribute(const T &data, const int threadID)
+{
+    //    CheckImpl("PutAttribute");
+    //    const std::string attributeName =
+    //        m_ImplDataDescriptor->ToString<decltype(attribute), attribute>();
+    //    m_ImplDataDescriptor->PutAttribute(attributeName, data, threadID);
+}
+
 template <auto entry, class T>
-void DataDescriptor::Put(const T &data, const int threadID)
+inline void DataDescriptor::Put(const T &data, const int threadID)
 {
     CheckImpl("Put");
     const std::string entryName =
@@ -28,8 +48,8 @@ void DataDescriptor::Put(const T &data, const int threadID)
 }
 
 template <auto entry, class T>
-void DataDescriptor::Put(const T *data, const Dimensions &dimensions,
-                         const int threadID)
+inline void DataDescriptor::Put(const T *data, const Dimensions &dimensions,
+                                const int threadID)
 {
     CheckImpl("Put");
     const std::string entryName =

--- a/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
+++ b/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#include <map>
+#include <set>
+#include <string>
+
 #include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
 
 namespace ncio
 {
-// TODO implement array data with dimensions
-
 #define declare_ncio_types(T)                                                  \
     template void DataDescriptor::Put<schema::nexus::bank##T::event_id>(       \
         const std::uint64_t &, const int);                                     \
@@ -49,5 +51,11 @@ NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
 
 NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
 #undef declare_ncio_types
+
+// check MACRO generation for expansion
+template schema::nexus::model1_t
+DataDescriptor::GetMetadata<schema::nexus::index::model1,
+                            schema::nexus::model1_t>(
+    const Parameters &parameters);
 
 }

--- a/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
+++ b/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
@@ -16,37 +16,65 @@
 
 namespace ncio
 {
+
+template void
+DataDescriptor::PutAttribute<schema::nexus::entry::NX_class, std::string>(
+    const int);
+
 #define declare_ncio_types(T)                                                  \
-    template void DataDescriptor::Put<schema::nexus::bank##T::event_id>(       \
-        const std::uint64_t &, const int);                                     \
-    template void DataDescriptor::Put<schema::nexus::bank##T::event_index>(    \
+    template void DataDescriptor::PutAttribute<                                \
+        schema::nexus::entry::bank##T##_events::NX_class, std::string>(        \
+        const int);
+
+NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
+#undef declare_ncio_types
+
+// use <std::string> to interpret the string literal as std::string not
+// char[]
+#define declare_ncio_types(T)                                                  \
+    template void                                                              \
+    DataDescriptor::Put<schema::nexus::entry::bank##T##_events::event_id>(     \
         const std::uint64_t *, const Dimensions &, const int);                 \
+                                                                               \
     template void                                                              \
-    DataDescriptor::Put<schema::nexus::bank##T::event_time_offset>(            \
+    DataDescriptor::Put<schema::nexus::entry::bank##T##_events::event_index>(  \
+        const std::uint64_t *, const Dimensions &, const int);                 \
+                                                                               \
+    template void DataDescriptor::Put<                                         \
+        schema::nexus::entry::bank##T##_events::event_time_offset>(            \
         const float *, const Dimensions &, const int);                         \
-    template void                                                              \
-    DataDescriptor::Put<schema::nexus::bank##T::event_time_zero>(              \
+                                                                               \
+    template void DataDescriptor::Put<                                         \
+        schema::nexus::entry::bank##T##_events::event_time_zero>(              \
         const double &, const int);                                            \
-    template void DataDescriptor::Put<schema::nexus::bank##T::total_counts>(   \
+                                                                               \
+    template void                                                              \
+    DataDescriptor::Put<schema::nexus::entry::bank##T##_events::total_counts>( \
         const float &, const int);
 
 NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
 #undef declare_ncio_types
 
 #define declare_ncio_types(T)                                                  \
-    template void DataDescriptor::Get<schema::nexus::bank##T::event_id>(       \
-        std::uint64_t &, const int);                                           \
-    template void DataDescriptor::Get<schema::nexus::bank##T::event_index>(    \
+                                                                               \
+    template void                                                              \
+    DataDescriptor::Get<schema::nexus::entry::bank##T##_events::event_id>(     \
         std::uint64_t *, const Box &box, const int);                           \
                                                                                \
     template void                                                              \
-    DataDescriptor::Get<schema::nexus::bank##T::event_time_offset>(            \
+    DataDescriptor::Get<schema::nexus::entry::bank##T##_events::event_index>(  \
+        std::uint64_t *, const Box &box, const int);                           \
+                                                                               \
+    template void DataDescriptor::Get<                                         \
+        schema::nexus::entry::bank##T##_events::event_time_offset>(            \
         float *, const Box &box, const int);                                   \
                                                                                \
-    template void                                                              \
-    DataDescriptor::Get<schema::nexus::bank##T::event_time_zero>(double &,     \
+    template void DataDescriptor::Get<                                         \
+        schema::nexus::entry::bank##T##_events::event_time_zero>(double &,     \
                                                                  const int);   \
-    template void DataDescriptor::Get<schema::nexus::bank##T::total_counts>(   \
+                                                                               \
+    template void                                                              \
+    DataDescriptor::Get<schema::nexus::entry::bank##T##_events::total_counts>( \
         float &, const int);
 
 NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project('ncio',
         license: 'BSD 3-Clause',
         version: '0.0.1',
         meson_version: '>=0.52.0',
-        default_options: ['cpp_std=c++17', 'buildtype=debug', 'layout=flat']
+        default_options: ['cpp_std=c++17', 'buildtype=release', 'layout=flat']
 )
 
 # SCHEMAS

--- a/source/ncio/common/ncioMacros.h
+++ b/source/ncio/common/ncioMacros.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <complex>
 #include <cstdint> //fixed-width types e.g. std::uint64_t
 
 #include "ncio/common/ncioTypes.h"
@@ -36,3 +35,11 @@
     MACRO(DataType::uint64, std::uint64_t)                                     \
     MACRO(DataType::float32, float)                                            \
     MACRO(DataType::float64, double)
+
+#define NCIO_ATTRIBUTE_DATATYPES(MACRO)                                        \
+    MACRO(std::string)                                                         \
+    NCIO_PRIMITIVE_TYPES(MACRO)
+
+#define NCIO_ATTRIBUTE_DATATYPES_2ARGS(MACRO)                                  \
+    MACRO(DataType::string, std::string)                                       \
+    NCIO_PRIMITIVE_DATATYPES_2ARGS(MACRO)

--- a/source/ncio/common/ncioTypes.h
+++ b/source/ncio/common/ncioTypes.h
@@ -55,6 +55,7 @@ enum class ShapeType
 /** enum class for data types used internally for entries */
 enum class DataType
 {
+    string,
     int8,
     int16,
     int32,

--- a/source/ncio/core/DataDescriptor.cpp
+++ b/source/ncio/core/DataDescriptor.cpp
@@ -143,8 +143,6 @@ DataDescriptor::Entry::Entry(const DataType dataType, std::any data,
 {
 }
 
-void DataDescriptor::InitMetadata(const Parameters &parameters) {}
-
 void DataDescriptor::InitTransport(const std::string &descriptorName,
                                    const OpenMode openMode,
                                    const Parameters &parameters)

--- a/source/ncio/core/DataDescriptor.cpp
+++ b/source/ncio/core/DataDescriptor.cpp
@@ -36,6 +36,26 @@ DataDescriptor::DataDescriptor(const std::string &descriptorName,
 
 void DataDescriptor::Execute(const int threadID)
 {
+    auto lf_ExecutePutAttributes =
+        [this](const std::map<std::string, Entry> &attributesMap,
+               const int threadID) {
+            for (const auto &attributePair : attributesMap)
+            {
+                const std::string &attributeName = attributePair.first;
+                const Entry &attributeEntry = attributePair.second;
+
+                switch (attributeEntry.dataType)
+                {
+#define declare_ncio_types(T, L)                                               \
+    case (T):                                                                  \
+        PutAttributeEntry<L>(attributeName, attributeEntry, threadID);         \
+        break;
+                    NCIO_ATTRIBUTE_DATATYPES_2ARGS(declare_ncio_types)
+#undef declare_ncio_types
+                }
+            }
+        };
+
     auto lf_ExecutePuts =
         [this](const std::map<std::string, std::vector<Entry>> &entriesMap,
                const int threadID) {
@@ -48,6 +68,10 @@ void DataDescriptor::Execute(const int threadID)
                 {
                     switch (entry.dataType)
                     {
+                    // TODO: add support for string variables, added to
+                    // avoid warning
+                    case (DataType::string):
+                        break;
 #define declare_ncio_types(T, L)                                               \
     case (T):                                                                  \
         PutEntry<L>(entryName, entry, threadID);                               \
@@ -73,6 +97,10 @@ void DataDescriptor::Execute(const int threadID)
 
                     switch (request.dataType)
                     {
+                        // TODO: add support for string variables, added to
+                        // avoid warning
+                    case (DataType::string):
+                        break;
 #define declare_ncio_types(T, L)                                               \
     case (T):                                                                  \
         m_Transport->Get<L>(entryName, std::any_cast<L *>(request.data), box,  \
@@ -93,6 +121,7 @@ void DataDescriptor::Execute(const int threadID)
     {
     case OpenMode::write:
         lf_ExecutePuts(itThreadID->second, threadID);
+        lf_ExecutePutAttributes(m_Attributes, threadID);
         break;
 
     case OpenMode::read:
@@ -107,6 +136,7 @@ void DataDescriptor::Execute(const int threadID)
     // always the same
     std::lock_guard<std::mutex> lock(m_Mutex);
     itThreadID->second.clear();
+    m_Attributes.clear();
 }
 
 std::future<void> DataDescriptor::ExecuteAsync(const std::launch launchMode,

--- a/source/ncio/core/DataDescriptor.h
+++ b/source/ncio/core/DataDescriptor.h
@@ -48,6 +48,9 @@ public:
     void Get(const std::string &entryName, T *data, const Box &box,
              const int threadID);
 
+    template <class Enum, Enum indexModel, class T>
+    T GetMetadata(const Parameters &parameters);
+
     /** Executes all Put or Get deferred tasks */
     void Execute(const int threadID);
 
@@ -139,12 +142,6 @@ private:
 
     /** private mutex for thread-safety operations */
     std::mutex m_Mutex;
-
-    /** In memory metadata entry index structure. Suitable for Nexus data */
-    std::map<std::string, std::set<std::string>> m_MetadataIndex1;
-
-    /** Init relevant metadata structures */
-    void InitMetadata(const Parameters &parameters);
 
     /**
      * Init transport backend resources (e.g. open a file)

--- a/source/ncio/core/DataDescriptor.tcc
+++ b/source/ncio/core/DataDescriptor.tcc
@@ -20,6 +20,40 @@ namespace ncio::core
 {
 
 template <class T>
+void DataDescriptor::PutAttribute(const std::string &entryName, const T &data,
+                                  const int threadID)
+{
+    auto itFind = m_Attributes.find(entryName);
+    if (itFind != m_Attributes.end())
+    {
+        return; // already created
+    }
+    std::lock_guard<std::mutex> lock(m_Mutex);
+    m_Attributes.emplace(entryName,
+                         Entry(helper::types::ToDataTypeEnum<T>(), data,
+                               DimensionsValue, ShapeType::value, Parameters(),
+                               nullptr));
+}
+
+template <class T>
+void DataDescriptor::PutAttribute(const std::string &attributeName,
+                                  const T *data, const Dimensions &dimensions,
+                                  const int threadID)
+{
+    // TODO: array attributes
+}
+
+#define declare_ncio_type(T)                                                   \
+    template void DataDescriptor::PutAttribute(const std::string &, const T &, \
+                                               const int);                     \
+                                                                               \
+    template void DataDescriptor::PutAttribute(const std::string &, const T *, \
+                                               const Dimensions &, const int);
+
+NCIO_ATTRIBUTE_DATATYPES(declare_ncio_type)
+#undef declare_ncio_type
+
+template <class T>
 void DataDescriptor::Put(const std::string &entryName, const T &data,
                          const int threadID)
 {
@@ -81,6 +115,27 @@ T DataDescriptor::GetMetadata(const Parameters &parameters)
 
 // PRIVATE
 template <class T>
+void DataDescriptor::PutAttributeEntry(const std::string &attributeName,
+                                       const Entry &entry, const int threadID)
+{
+    switch (entry.shapeType)
+    {
+    case (ShapeType::value): {
+        const T *data = std::any_cast<const T>(&entry.data);
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        {
+            m_Transport->PutAttribute(attributeName, data, DimensionsValue,
+                                      threadID);
+        }
+        break;
+    }
+    case (ShapeType::array): {
+        break;
+    }
+    }
+}
+
+template <class T>
 void DataDescriptor::PutEntry(const std::string &entryName, const Entry &entry,
                               const int threadID)
 {
@@ -115,6 +170,7 @@ void DataDescriptor::GetEntry(const std::string &entryName, Entry &entry,
     {
     case (ShapeType::value): {
         T *data = std::any_cast<T>(&entry.data);
+        // TODO: rethink when backends allow truly threaded code
         std::lock_guard<std::mutex> lock(m_Mutex);
         {
             m_Transport->Get(entryName, data, DimensionsValue, threadID);
@@ -124,6 +180,7 @@ void DataDescriptor::GetEntry(const std::string &entryName, Entry &entry,
     case (ShapeType::array): {
         // TODO some checks on Dimensions
         T *data = std::any_cast<T *>(entry.data);
+        // TODO: rethink when backends allow truly threaded code
         std::lock_guard<std::mutex> lock(m_Mutex);
         {
             m_Transport->Get(entryName, data, std::get<Box>(entry.query),

--- a/source/ncio/core/DataDescriptor.tcc
+++ b/source/ncio/core/DataDescriptor.tcc
@@ -12,9 +12,9 @@
 
 #include "ncio/common/ncioTypes.h" // Dimensions
 #include "ncio/helper/ncioHelperTypes.h"
-#include "ncio/ncioConfig.h"
-
 #include "ncio/transport/Transport.h"
+
+#include "ncio/ncioConfig.h"
 
 namespace ncio::core
 {
@@ -71,6 +71,13 @@ void DataDescriptor::Get(const std::string &entryName, T *data, const Box &box,
 
 NCIO_PRIMITIVE_TYPES(declare_ncio_type)
 #undef declare_ncio_type
+
+template <class Enum, Enum indexModel, class T>
+T DataDescriptor::GetMetadata(const Parameters &parameters)
+{
+    // for now it assumes metadata is 1-to-1 from a single transport
+    return m_Transport->GetMetadata<Enum, indexModel, T>(parameters);
+}
 
 // PRIVATE
 template <class T>
@@ -129,7 +136,6 @@ void DataDescriptor::GetEntry(const std::string &entryName, Entry &entry,
 
 } // end namespace ncio::core
 
-// Schema implements ncio::core::DataDescriptor::ToString
 #ifdef NCIO_HAVE_SCHEMA_NEXUS
 #include "ncio/schema/nexus/DataDescriptorNexus.tcc"
 #endif

--- a/source/ncio/helper/ncioHelperTypes.tcc
+++ b/source/ncio/helper/ncioHelperTypes.tcc
@@ -14,6 +14,7 @@ namespace ncio::helper::types
 {
 
 #define NCIO_TYPES_ENUM(MACRO)                                                 \
+    MACRO(std::string, DataType::string)                                       \
     MACRO(std::int8_t, DataType::int8)                                         \
     MACRO(std::int16_t, DataType::int16)                                       \
     MACRO(std::int32_t, DataType::int32)                                       \

--- a/source/ncio/schema/nexus/DataDescriptorNexus.tcc
+++ b/source/ncio/schema/nexus/DataDescriptorNexus.tcc
@@ -5,6 +5,7 @@
  *  Created on: Jun 16, 2020
  *      Author: William F Godoy godoywf@ornl.gov
  */
+#pragma once
 
 #include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
 
@@ -34,4 +35,8 @@ namespace ncio::core
 NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_type)
 #undef declare_ncio_type
 
+template schema::nexus::model1_t
+DataDescriptor::GetMetadata<schema::nexus::index, schema::nexus::index::model1,
+                            schema::nexus::model1_t>(
+    const Parameters &parameters);
 }

--- a/source/ncio/schema/nexus/DataDescriptorNexus.tcc
+++ b/source/ncio/schema/nexus/DataDescriptorNexus.tcc
@@ -15,26 +15,60 @@ namespace ncio::core
 // first. This is required by clang (it will fail), but not by gcc
 
 // Implement DataDescriptor::ToString for Schema entries
-#define NCIO_SCHEMA_NEXUS_TOSTRING(bank, entry)                                \
+#define NCIO_SCHEMA_NEXUS_TOSTRING(bankID_events, entryName)                   \
     template <>                                                                \
-    std::string DataDescriptor::ToString<schema::nexus::bank,                  \
-                                         schema::nexus::bank::entry>()         \
+    std::string                                                                \
+    DataDescriptor::ToString<schema::nexus::entry::bankID_events,              \
+                             schema::nexus::entry::bankID_events::entryName>() \
         const noexcept                                                         \
     {                                                                          \
-        return std::string("/entry/").append(#bank).append("/").append(        \
-            #entry);                                                           \
+        return std::string("/entry/")                                          \
+            .append(#bankID_events)                                            \
+            .append("/")                                                       \
+            .append(#entryName);                                               \
     }
 
 #define declare_ncio_type(T)                                                   \
-    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T, event_id)                              \
-    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T, event_index)                           \
-    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T, event_time_offset)                     \
-    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T, event_time_zero)                       \
-    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T, total_counts)
+    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T##_events, event_id)                     \
+    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T##_events, event_index)                  \
+    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T##_events, event_time_offset)            \
+    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T##_events, event_time_zero)              \
+    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T##_events, total_counts)                 \
+    NCIO_SCHEMA_NEXUS_TOSTRING(bank##T##_events, NX_class)
 
 NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_type)
 #undef declare_ncio_type
 
+#define NCIO_SCHEMA_NEXUS_BANKID_NX_Class(bankID_events)                       \
+    template <>                                                                \
+    std::string DataDescriptor::AttributeData<                                 \
+        decltype(schema::nexus::entry::bankID_events::NX_class),               \
+        schema::nexus::entry::bankID_events::NX_class, std::string>()          \
+        const noexcept                                                         \
+    {                                                                          \
+        return "NXevent_data";                                                 \
+    }
+
+#define declare_ncio_type(T) NCIO_SCHEMA_NEXUS_BANKID_NX_Class(bank##T##_events)
+
+NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_type)
+#undef declare_ncio_type
+
+template <>
+std::string
+DataDescriptor::ToString<int, schema::nexus::entry::NX_class>() const noexcept
+{
+    return "/entry/NX_class";
+}
+
+template <>
+std::string DataDescriptor::AttributeData<int, schema::nexus::entry::NX_class,
+                                          std::string>() const noexcept
+{
+    return "NXentry";
+}
+
+// In-memory INDEX
 template schema::nexus::model1_t
 DataDescriptor::GetMetadata<schema::nexus::index, schema::nexus::index::model1,
                             schema::nexus::model1_t>(

--- a/source/ncio/schema/nexus/TransportHDF5Nexus.tcc
+++ b/source/ncio/schema/nexus/TransportHDF5Nexus.tcc
@@ -65,8 +65,10 @@ void TransportHDF5::DoGetMetadataNexus(schema::nexus::model1_t &index,
         [&](schema::nexus::model1_t &index, hid_t groupID) {
             const std::size_t groupNameLength =
                 static_cast<std::size_t>(H5Iget_name(groupID, NULL, 0));
-            std::vector<char> groupName(groupNameLength);
-            H5Iget_name(groupID, groupName.data(), groupNameLength);
+
+            std::vector<char> groupName(groupNameLength + 1);
+            H5Iget_name(groupID, groupName.data(), groupNameLength + 1);
+            groupName.resize(groupNameLength);
 
             hsize_t nObjects = 0;
             H5Gget_num_objs(groupID, &nObjects);
@@ -94,9 +96,10 @@ void TransportHDF5::DoGetMetadataNexus(schema::nexus::model1_t &index,
                     static_cast<std::size_t>(H5Gget_objname_by_idx(
                         groupID, static_cast<hsize_t>(i), NULL, 0));
                 memberName.clear();
-                memberName.resize(memberNameLength);
+                memberName.resize(memberNameLength + 1);
                 H5Gget_objname_by_idx(groupID, static_cast<hsize_t>(i),
-                                      memberName.data(), memberNameLength);
+                                      memberName.data(), memberNameLength + 1);
+                memberName.resize(memberNameLength);
 
                 if (type == H5O_TYPE_GROUP)
                 {
@@ -118,7 +121,9 @@ void TransportHDF5::DoGetMetadataNexus(schema::nexus::model1_t &index,
 
     // need a callable fully defined lambda function as the search is done
     // recursively
+    m_TopGroupID = H5Gopen2(m_File, "/", H5P_DEFAULT);
     lf_GetGroup(index, m_TopGroupID);
+    H5Gclose(m_TopGroupID);
 }
 
 }

--- a/source/ncio/schema/nexus/TransportHDF5Nexus.tcc
+++ b/source/ncio/schema/nexus/TransportHDF5Nexus.tcc
@@ -1,0 +1,121 @@
+/**
+ * TransportHDF5Nexus.tcc : compile-time specific extension of the TransportHDF5
+ * functions that need to be NeXus schema aware
+ *
+ *  Created on: Jan 20, 2021
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
+
+#include "ncio/transport/TransportHDF5.h"
+
+namespace ncio::transport
+{
+
+void TransportHDF5::DoGetMetadataNexus(schema::nexus::model1_t &index,
+                                       const schema::nexus::index model,
+                                       const Parameters &parameters)
+{
+    auto lf_getNxClassAttribute = [&](hid_t groupID,
+                                      const char *objectName) -> std::string {
+        std::string attribute = "";
+        hid_t attributeID = H5Aopen_by_name(groupID, objectName, "NX_class",
+                                            H5P_DEFAULT, H5P_DEFAULT);
+        if (attributeID < 0)
+        {
+            // non-existent for scientific dataset "SDS" cases
+            H5Aclose(attributeID);
+            return attribute;
+        }
+
+        hid_t type = H5Aget_type(attributeID);
+        hid_t typeClass = H5Tget_class(type);
+        if (typeClass != H5T_STRING)
+        {
+            throw std::runtime_error("ncio ERROR: schema NeXus attribute "
+                                     "NX_class is not string type\n");
+        }
+
+        // using 128 characters, NX_class attributes not expected to be longer
+        // than this
+        std::vector<char> attributeVector(128);
+        // needs native type
+        hid_t memoryType = H5Tget_native_type(type, H5T_DIR_ASCEND);
+        herr_t status =
+            H5Aread(attributeID, memoryType, attributeVector.data());
+        if (status < 0)
+        {
+            throw std::runtime_error("ncio ERROR: schema NeXus attribute "
+                                     "NX_class could not be read\n");
+        }
+
+        H5Tclose(memoryType);
+        H5Aclose(attributeID);
+
+        attribute = std::string(attributeVector.data());
+        return attribute;
+    };
+
+    // need a callable lambda function as the search is done recursively
+    auto lf_GetGroup = [](schema::nexus::model1_t &index, hid_t groupID) {
+        const std::size_t groupNameLength =
+            static_cast<std::size_t>(H5Iget_name(groupID, NULL, 0));
+        std::vector<char> groupName(groupNameLength);
+        H5Iget_name(groupID, groupName.data(), groupNameLength);
+
+        hsize_t nObjects = 0;
+        H5Gget_num_objs(groupID, &nObjects);
+
+        // convert to string to compare
+        const std::string groupNameStr(groupName.data());
+        const std::string nxClass =
+            (groupNameStr == m_TopGroupID)
+                ? ""
+                : lf_getNxClassAttribute(groupID, groupNameStr.c_str());
+
+        if (!nxClass.empty())
+        {
+            index[nxClass].insert(groupNameStr);
+        }
+
+        std::vector<char> memberName;
+
+        for (unsigned int i = 0; i < nObjects; ++i)
+        {
+            const int type =
+                H5Gget_objtype_by_idx(groupID, static_cast<size_t>(i));
+
+            const std::size_t memberNameLength =
+                static_cast<std::size_t>(H5Gget_objname_by_idx(
+                    groupID, static_cast<hsize_t>(i), NULL, 0));
+            memberName.clear();
+            memberName.resize(memberNameLength);
+            H5Gget_objname_by_idx(groupID, static_cast<hsize_t>(i),
+                                  memberName.data(), memberNameLength);
+
+            if (type == H5O_TYPE_GROUP)
+            {
+                hid_t subGroupID =
+                    H5Gopen2(groupID, memberName.data(), H5P_DEFAULT);
+                lf_GetGroup(subGroupID, index);
+                H5Gclose(subGroupID);
+            }
+            else if (type == H5O_TYPE_DATASET)
+            {
+                const std::string memberNameStr(memberName.data(),
+                                                memberNameLength);
+                const std::string absoluteEntryName =
+                    groupNameStr + "/" + memberNameStr;
+                index["SDS"].insert(absoluteEntryName);
+            }
+        }
+    };
+
+    // need a callable lambda function as the search is done recursively
+    lf_GetGroup(m_TopGroupID, index);
+}
+
+}

--- a/source/ncio/schema/nexus/TransportHDF5Nexus.tcc
+++ b/source/ncio/schema/nexus/TransportHDF5Nexus.tcc
@@ -9,8 +9,9 @@
 #pragma once
 
 #include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
-
 #include "ncio/transport/TransportHDF5.h"
+
+#include <functional>
 
 namespace ncio::transport
 {
@@ -60,62 +61,64 @@ void TransportHDF5::DoGetMetadataNexus(schema::nexus::model1_t &index,
     };
 
     // need a callable lambda function as the search is done recursively
-    auto lf_GetGroup = [](schema::nexus::model1_t &index, hid_t groupID) {
-        const std::size_t groupNameLength =
-            static_cast<std::size_t>(H5Iget_name(groupID, NULL, 0));
-        std::vector<char> groupName(groupNameLength);
-        H5Iget_name(groupID, groupName.data(), groupNameLength);
+    std::function<void(schema::nexus::model1_t &, hid_t)> lf_GetGroup =
+        [&](schema::nexus::model1_t &index, hid_t groupID) {
+            const std::size_t groupNameLength =
+                static_cast<std::size_t>(H5Iget_name(groupID, NULL, 0));
+            std::vector<char> groupName(groupNameLength);
+            H5Iget_name(groupID, groupName.data(), groupNameLength);
 
-        hsize_t nObjects = 0;
-        H5Gget_num_objs(groupID, &nObjects);
+            hsize_t nObjects = 0;
+            H5Gget_num_objs(groupID, &nObjects);
 
-        // convert to string to compare
-        const std::string groupNameStr(groupName.data());
-        const std::string nxClass =
-            (groupNameStr == m_TopGroupID)
-                ? ""
-                : lf_getNxClassAttribute(groupID, groupNameStr.c_str());
+            // convert to string to compare
+            const std::string groupNameStr(groupName.data());
+            const std::string nxClass =
+                (groupNameStr == "/")
+                    ? ""
+                    : lf_getNxClassAttribute(groupID, groupNameStr.c_str());
 
-        if (!nxClass.empty())
-        {
-            index[nxClass].insert(groupNameStr);
-        }
-
-        std::vector<char> memberName;
-
-        for (unsigned int i = 0; i < nObjects; ++i)
-        {
-            const int type =
-                H5Gget_objtype_by_idx(groupID, static_cast<size_t>(i));
-
-            const std::size_t memberNameLength =
-                static_cast<std::size_t>(H5Gget_objname_by_idx(
-                    groupID, static_cast<hsize_t>(i), NULL, 0));
-            memberName.clear();
-            memberName.resize(memberNameLength);
-            H5Gget_objname_by_idx(groupID, static_cast<hsize_t>(i),
-                                  memberName.data(), memberNameLength);
-
-            if (type == H5O_TYPE_GROUP)
+            if (!nxClass.empty())
             {
-                hid_t subGroupID =
-                    H5Gopen2(groupID, memberName.data(), H5P_DEFAULT);
-                lf_GetGroup(subGroupID, index);
-                H5Gclose(subGroupID);
+                index[nxClass].insert(groupNameStr);
             }
-            else if (type == H5O_TYPE_DATASET)
-            {
-                const std::string memberNameStr(memberName.data(),
-                                                memberNameLength);
-                const std::string absoluteEntryName =
-                    groupNameStr + "/" + memberNameStr;
-                index["SDS"].insert(absoluteEntryName);
-            }
-        }
-    };
 
-    // need a callable lambda function as the search is done recursively
-    lf_GetGroup(m_TopGroupID, index);
+            std::vector<char> memberName;
+
+            for (unsigned int i = 0; i < nObjects; ++i)
+            {
+                const int type =
+                    H5Gget_objtype_by_idx(groupID, static_cast<size_t>(i));
+
+                const std::size_t memberNameLength =
+                    static_cast<std::size_t>(H5Gget_objname_by_idx(
+                        groupID, static_cast<hsize_t>(i), NULL, 0));
+                memberName.clear();
+                memberName.resize(memberNameLength);
+                H5Gget_objname_by_idx(groupID, static_cast<hsize_t>(i),
+                                      memberName.data(), memberNameLength);
+
+                if (type == H5O_TYPE_GROUP)
+                {
+                    hid_t subGroupID =
+                        H5Gopen2(groupID, memberName.data(), H5P_DEFAULT);
+                    lf_GetGroup(index, subGroupID);
+                    H5Gclose(subGroupID);
+                }
+                else if (type == H5O_TYPE_DATASET)
+                {
+                    const std::string memberNameStr(memberName.data(),
+                                                    memberNameLength);
+                    const std::string absoluteEntryName =
+                        groupNameStr + "/" + memberNameStr;
+                    index["SDS"].insert(absoluteEntryName);
+                }
+            }
+        };
+
+    // need a callable fully defined lambda function as the search is done
+    // recursively
+    lf_GetGroup(index, m_TopGroupID);
 }
 
 }

--- a/source/ncio/schema/nexus/TransportNexus.tcc
+++ b/source/ncio/schema/nexus/TransportNexus.tcc
@@ -1,0 +1,26 @@
+/**
+ * TransportNexus.tcc
+ *
+ *  Created on: Jan 19, 2021
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
+#include "ncio/transport/Transport.h"
+
+namespace ncio::transport
+{
+
+template <>
+schema::nexus::model1_t
+Transport::GetMetadata<schema::nexus::index, schema::nexus::index::model1,
+                       schema::nexus::model1_t>(const Parameters &parameters)
+{
+    schema::nexus::model1_t index;
+    DoGetMetadataNexus(index, schema::nexus::index::model1, parameters);
+    return index;
+}
+
+}

--- a/source/ncio/schema/nexus/TransportNullNexus.tcc
+++ b/source/ncio/schema/nexus/TransportNullNexus.tcc
@@ -1,0 +1,23 @@
+/**
+ * TransportNullNexus.tcc
+ *
+ *  Created on: Jan 20, 2021
+ *      Author: wgodoy
+ */
+
+#pragma once
+
+#include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
+
+#include "ncio/transport/TransportNull.h"
+
+namespace ncio::transport
+{
+
+void TransportNull::DoGetMetadataNexus(schema::nexus::model1_t &index,
+                                       const schema::nexus::index model,
+                                       const Parameters &parameters)
+{
+}
+
+}

--- a/source/ncio/schema/nexus/ncioTypesSchemaNexus.h
+++ b/source/ncio/schema/nexus/ncioTypesSchemaNexus.h
@@ -296,9 +296,15 @@ using model1_t = std::map<std::string, std::set<std::string>>;
     MACRO(_error)                                                              \
     MACRO(_unmapped)
 
+namespace entry
+{
+
+constexpr int NX_class = 0;
+
 #define declare_nexus_banks_enum_entries(T)                                    \
-    enum class bank##T{event_id, event_index, event_time_offset,               \
-                       event_time_zero, total_counts};
+    enum class bank##T##_events{event_id,          event_index,                \
+                                event_time_offset, event_time_zero,            \
+                                total_counts,      NX_class};
 
 NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_nexus_banks_enum_entries)
 #undef declare_nexus_banks_enum_entries
@@ -356,4 +362,6 @@ enum class user
     name
 };
 
-} // end namespace ncio::nexus
+} // end namespace entry
+
+} // end namespace ncio::schema::nexus

--- a/source/ncio/schema/nexus/ncioTypesSchemaNexus.h
+++ b/source/ncio/schema/nexus/ncioTypesSchemaNexus.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include <cstdint> //fixed-width types e.g. std::uint64_t
+#include <map>
+#include <set>
+#include <string>
 
 /**
  * Define inputs to NCIO API functions that are specific to the NeXus schema
@@ -17,6 +20,15 @@
  */
 namespace ncio::schema::nexus
 {
+
+enum class index
+{
+    model1
+};
+
+using model1_t = std::map<std::string, std::set<std::string>>;
+
+#define NCIO_MACRO_NEXUS_INDEX_MODEL(MACRO) MACRO(ncio::schema::nexus::model1_t)
 
 #define NCIO_MACRO_NEXUS_TYPES(MACRO)                                          \
     MACRO(std::uint32_t)                                                       \

--- a/source/ncio/transport/Transport.cpp
+++ b/source/ncio/transport/Transport.cpp
@@ -31,4 +31,4 @@ void Transport::Close()
 
 std::any Transport::GetNativeHandler() noexcept { return DoGetNativeHandler(); }
 
-} // end namespace ncio::io
+}

--- a/source/ncio/transport/Transport.h
+++ b/source/ncio/transport/Transport.h
@@ -50,6 +50,10 @@ public:
     template <class Enum, Enum indexModel, class T>
     T GetMetadata(const Parameters &parameters);
 
+    template <class T>
+    void PutAttribute(const std::string &entryName, const T *data,
+                      const Dimensions &dimensions, const int threadID);
+
     /** Write a variable entry by name and optional dimensions */
     template <class T>
     void Put(const std::string &entryName, const T *data,
@@ -85,6 +89,14 @@ protected:
 
     /** flag to check if m_File is open and close it in destructor (RAII) */
     bool m_IsOpen = false;
+
+#define declare_ncio_type(T)                                                   \
+    virtual void DoPutAttribute(const std::string &attributeName,              \
+                                const T *data, const Dimensions &dimensions,   \
+                                const int threadID) = 0;
+
+    NCIO_ATTRIBUTE_DATATYPES(declare_ncio_type)
+#undef declare_ncio_type
 
 #define declare_ncio_type(T)                                                   \
     virtual void DoPut(const std::string &entryName, const T *data,            \

--- a/source/ncio/transport/Transport.tcc
+++ b/source/ncio/transport/Transport.tcc
@@ -15,6 +15,22 @@ namespace ncio::transport
 {
 
 template <class T>
+void Transport::PutAttribute(const std::string &entryName, const T *data,
+                             const Dimensions &dimensions, const int threadID)
+{
+    DoPutAttribute(entryName, data, dimensions, threadID);
+}
+
+// REGISTER GENERAL TYPES for PutAttribute
+#define declare_ncio_type(T)                                                   \
+    template void Transport::PutAttribute<T>(const std::string &, const T *,   \
+                                             const Dimensions &,               \
+                                             const int threadID);
+
+NCIO_ATTRIBUTE_DATATYPES(declare_ncio_type)
+#undef declare_ncio_type
+
+template <class T>
 void Transport::Put(const std::string &entryName, const T *data,
                     const Dimensions &dimensions, const int threadID)
 {

--- a/source/ncio/transport/Transport.tcc
+++ b/source/ncio/transport/Transport.tcc
@@ -9,19 +9,10 @@
 
 #include "Transport.h"
 
+#include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
+
 namespace ncio::transport
 {
-
-template <class T>
-T Transport::GetMetadata()
-{
-    T index;
-    DoGetMetadata(index);
-    return index;
-}
-
-// REGISTER TYPES for GetMetadata
-template std::map<std::string, std::set<std::string>> Transport::GetMetadata();
 
 template <class T>
 void Transport::Put(const std::string &entryName, const T *data,
@@ -30,7 +21,7 @@ void Transport::Put(const std::string &entryName, const T *data,
     DoPut(entryName, data, dimensions, threadID);
 }
 
-// REGISTER TYPES for Put
+// REGISTER GENERAL TYPES for Put
 #define declare_ncio_type(T)                                                   \
     template void Transport::Put<T>(const std::string &, const T *,            \
                                     const Dimensions &, const int threadID);
@@ -45,7 +36,7 @@ void Transport::Get(const std::string &entryName, T *data, const Box &box,
     DoGet(entryName, data, box, threadID);
 }
 
-// REGISTER TYPES for Get
+// REGISTER GENERAL TYPES for Get
 #define declare_ncio_type(T)                                                   \
     template void Transport::Get<T>(const std::string &, T *, const Box &,     \
                                     const int threadID);
@@ -53,4 +44,8 @@ void Transport::Get(const std::string &entryName, T *data, const Box &box,
 NCIO_PRIMITIVE_TYPES(declare_ncio_type)
 #undef declare_ncio_type
 
-} // end namespace ncio::io
+}
+
+#ifdef NCIO_HAVE_SCHEMA_NEXUS
+#include "ncio/schema/nexus/TransportNexus.tcc"
+#endif

--- a/source/ncio/transport/TransportHDF5.cpp
+++ b/source/ncio/transport/TransportHDF5.cpp
@@ -72,11 +72,6 @@ TransportHDF5::~TransportHDF5()
 }
 
 // PRIVATE
-void TransportHDF5::DoGetMetadata(
-    std::map<std::string, std::set<std::string> > &index)
-{
-}
-
 // will need to specialize for each HDF5 type
 #define declare_ncio_type(T)                                                   \
     void TransportHDF5::DoPut(const std::string &entryName, const T *data,     \
@@ -122,5 +117,11 @@ void TransportHDF5::CloseDataset(std::vector<hid_t> &handlers)
         }
     }
 }
+
+
+
+
+
+
 
 } // end namespace ncio::io

--- a/source/ncio/transport/TransportHDF5.cpp
+++ b/source/ncio/transport/TransportHDF5.cpp
@@ -72,7 +72,18 @@ TransportHDF5::~TransportHDF5()
 }
 
 // PRIVATE
-// will need to specialize for each HDF5 type
+
+#define declare_ncio_type(T)                                                   \
+    void TransportHDF5::DoPutAttribute(                                        \
+        const std::string &entryName, const T *data,                           \
+        const Dimensions &dimensions, const int threadID)                      \
+    {                                                                          \
+        DoPutAttributeCommon(entryName, data, dimensions, threadID);           \
+    }
+
+NCIO_ATTRIBUTE_DATATYPES(declare_ncio_type)
+#undef declare_ncio_type
+
 #define declare_ncio_type(T)                                                   \
     void TransportHDF5::DoPut(const std::string &entryName, const T *data,     \
                               const Dimensions &dimensions,                    \
@@ -117,11 +128,5 @@ void TransportHDF5::CloseDataset(std::vector<hid_t> &handlers)
         }
     }
 }
-
-
-
-
-
-
 
 } // end namespace ncio::io

--- a/source/ncio/transport/TransportHDF5.h
+++ b/source/ncio/transport/TransportHDF5.h
@@ -35,6 +35,14 @@ private:
     hid_t m_TopGroupID = -1;
 
 #define declare_ncio_type(T)                                                   \
+    void DoPutAttribute(const std::string &attributeName, const T *data,       \
+                        const Dimensions &dimensions, const int threadID)      \
+        final;
+
+    NCIO_ATTRIBUTE_DATATYPES(declare_ncio_type)
+#undef declare_ncio_type
+
+#define declare_ncio_type(T)                                                   \
     void DoPut(const std::string &entryName, const T *data,                    \
                const Dimensions &dimensions, const int threadID) final;        \
                                                                                \
@@ -43,6 +51,10 @@ private:
 
     NCIO_PRIMITIVE_TYPES(declare_ncio_type)
 #undef declare_ncio_type
+
+    template <class T>
+    void DoPutAttributeCommon(const std::string &attributeName, const T *data,
+                              const Dimensions &dimensions, const int threadID);
 
     template <class T>
     void DoPutCommon(const std::string &entryName, const T *data,
@@ -59,9 +71,17 @@ private:
     template <class T>
     hid_t GetHDF5Datatype();
 
+    /**
+     * Creates a hierarchy of groups
+     * @tparam T
+     * @param entryName
+     * @param fileSpace
+     * @param isDataset
+     * @return
+     */
     template <class T>
-    std::vector<hid_t> CreateDataset(const std::string &entryName,
-                                     hid_t fileSpace);
+    std::vector<hid_t> CreateIDs(const std::string &entryName, hid_t fileSpace,
+                                 const bool isDataset = true);
 
     void CloseDataset(std::vector<hid_t> &handlers);
 

--- a/source/ncio/transport/TransportHDF5.h
+++ b/source/ncio/transport/TransportHDF5.h
@@ -34,9 +34,6 @@ private:
     /** generated Id for top level group "/" */
     hid_t m_TopGroupID = -1;
 
-    void
-    DoGetMetadata(std::map<std::string, std::set<std::string>> &index) final;
-
 #define declare_ncio_type(T)                                                   \
     void DoPut(const std::string &entryName, const T *data,                    \
                const Dimensions &dimensions, const int threadID) final;        \
@@ -67,6 +64,15 @@ private:
                                      hid_t fileSpace);
 
     void CloseDataset(std::vector<hid_t> &handlers);
+
+#ifdef NCIO_HAVE_SCHEMA_NEXUS
+#define declare_ncio_type(T)                                                   \
+    void DoGetMetadataNexus(T &index, const schema::nexus::index model,        \
+                            const Parameters &parameters) final;
+
+    NCIO_MACRO_NEXUS_INDEX_MODEL(declare_ncio_type)
+#undef declare_ncio_type
+#endif
 };
 
-} // end namespace nexus::io
+}

--- a/source/ncio/transport/TransportHDF5.tcc
+++ b/source/ncio/transport/TransportHDF5.tcc
@@ -113,7 +113,7 @@ void TransportHDF5::DoPutAttributeCommon<std::string>(
 
         hid_t attributeSpace = H5Screate(H5S_SCALAR);
         hid_t attributeType = H5Tcopy(H5T_C_S1);
-        H5Tset_size(attributeType, attributeName.size());
+        H5Tset_size(attributeType, data->size());
         H5Tset_strpad(attributeType, H5T_STR_NULLTERM);
 
         const std::vector<hid_t> ids =

--- a/source/ncio/transport/TransportHDF5.tcc
+++ b/source/ncio/transport/TransportHDF5.tcc
@@ -18,6 +18,7 @@ namespace ncio::transport
 {
 
 #define NCIO_HD5Types_MAP(MACRO)                                               \
+    MACRO(std::string, H5T_STRING)                                             \
     MACRO(std::int8_t, H5T_STD_I8LE)                                           \
     MACRO(std::int16_t, H5T_STD_I16LE)                                         \
     MACRO(std::int32_t, H5T_STD_I32LE)                                         \
@@ -40,8 +41,9 @@ NCIO_HD5Types_MAP(declare_ncio_types)
 #undef declare_ncio_types
 
     template <class T>
-    std::vector<hid_t> TransportHDF5::CreateDataset(
-        const std::string &entryName, hid_t fileSpace)
+    std::vector<hid_t> TransportHDF5::CreateIDs(const std::string &entryName,
+                                                hid_t fileSpace,
+                                                const bool isDataSet)
 {
     const std::vector<std::string> list = helper::string::Split(entryName);
     std::vector<hid_t> datasetChain;
@@ -69,6 +71,11 @@ NCIO_HD5Types_MAP(declare_ncio_types)
         }
     }
 
+    if (!isDataSet)
+    {
+        return datasetChain;
+    }
+
     // create dataset inside the last group
     hid_t datasetID = -1;
     if (H5Lexists(groupID, list.back().c_str(), H5P_DEFAULT) == 0)
@@ -85,6 +92,52 @@ NCIO_HD5Types_MAP(declare_ncio_types)
     datasetChain.push_back(datasetID);
 
     return datasetChain;
+}
+
+// specialize for std::string
+template <>
+void TransportHDF5::DoPutAttributeCommon<std::string>(
+    const std::string &attributeName, const std::string *data,
+    const Dimensions &dimensions, const int threadID)
+{
+    // support attribute string writing with HDF5
+    if (dimensions == DimensionsValue)
+    {
+        // check if attribute exist, if it does don't overwrite. First come,
+        // first served.
+        hid_t attributeID = H5Aexists(m_File, attributeName.c_str());
+        if (attributeID != 0)
+        {
+            return;
+        }
+
+        hid_t attributeSpace = H5Screate(H5S_SCALAR);
+        hid_t attributeType = H5Tcopy(H5T_C_S1);
+        H5Tset_size(attributeType, attributeName.size());
+        H5Tset_strpad(attributeType, H5T_STR_NULLTERM);
+
+        const std::vector<hid_t> ids =
+            CreateIDs<int>(attributeName, attributeSpace, false);
+
+        const std::vector<std::string> list =
+            helper::string::Split(attributeName);
+
+        attributeID = H5Acreate2(ids.back(), list.back().c_str(), attributeType,
+                                 attributeSpace, H5P_DEFAULT, H5P_DEFAULT);
+
+        H5Awrite(attributeID, attributeType, data->c_str());
+        H5Sclose(attributeSpace);
+        H5Tclose(attributeType);
+        H5Aclose(attributeID);
+    }
+}
+
+template <class T>
+inline void TransportHDF5::DoPutAttributeCommon(const std::string &entryName,
+                                                const T *data,
+                                                const Dimensions &dimensions,
+                                                const int threadID)
+{
 }
 
 template <class T>
@@ -105,7 +158,7 @@ void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
     if (dimensions == DimensionsValue)
     {
         hid_t fileSpace = H5Screate(H5S_SCALAR);
-        std::vector<hid_t> listIDs = CreateDataset<T>(entryName, fileSpace);
+        std::vector<hid_t> listIDs = CreateIDs<T>(entryName, fileSpace);
         hid_t datasetID = listIDs.back();
         hid_t status = H5Dwrite(datasetID, GetHDF5Datatype<T>(), H5S_ALL,
                                 H5S_ALL, H5P_DEFAULT, data);
@@ -125,7 +178,7 @@ void TransportHDF5::DoPutCommon(const std::string &entryName, const T *data,
 
         // create file space and dataset
         hid_t fileSpace = lf_H5SCreateSimple(shape);
-        std::vector<hid_t> listIDs = CreateDataset<T>(entryName, fileSpace);
+        std::vector<hid_t> listIDs = CreateIDs<T>(entryName, fileSpace);
 
         // retrieve fileSpace from dataset and set hyperslab box selection
         hid_t datasetID = listIDs.back();

--- a/source/ncio/transport/TransportHDF5.tcc
+++ b/source/ncio/transport/TransportHDF5.tcc
@@ -208,4 +208,8 @@ void TransportHDF5::DoGetCommon(const std::string &entryName, T *data,
     }
 }
 
-} // end namespace ncio::transport
+}
+
+#ifdef NCIO_HAVE_SCHEMA_NEXUS
+#include "ncio/schema/nexus/TransportHDF5Nexus.tcc"
+#endif

--- a/source/ncio/transport/TransportNull.cpp
+++ b/source/ncio/transport/TransportNull.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TransportNull.h"
+#include "TransportNull.tcc"
 
 namespace ncio::transport
 {
@@ -18,11 +19,6 @@ TransportNull::TransportNull(const std::string &name, const OpenMode openMode,
 }
 
 // PRIVATE
-void TransportNull::DoGetMetadata(
-    std::map<std::string, std::set<std::string>> &index)
-{
-}
-
 #define declare_ncio_types(T)                                                  \
     void TransportNull::DoPut(const std::string &entryName, const T *data,     \
                               const Dimensions &dimensions,                    \

--- a/source/ncio/transport/TransportNull.cpp
+++ b/source/ncio/transport/TransportNull.cpp
@@ -19,6 +19,16 @@ TransportNull::TransportNull(const std::string &name, const OpenMode openMode,
 }
 
 // PRIVATE
+#define declare_ncio_type(T)                                                   \
+    void TransportNull::DoPutAttribute(                                        \
+        const std::string &entryName, const T *data,                           \
+        const Dimensions &dimensions, const int threadID)                      \
+    {                                                                          \
+    }
+
+NCIO_ATTRIBUTE_DATATYPES(declare_ncio_type)
+#undef declare_ncio_type
+
 #define declare_ncio_types(T)                                                  \
     void TransportNull::DoPut(const std::string &entryName, const T *data,     \
                               const Dimensions &dimensions,                    \

--- a/source/ncio/transport/TransportNull.h
+++ b/source/ncio/transport/TransportNull.h
@@ -22,6 +22,14 @@ public:
 
 private:
 #define declare_ncio_type(T)                                                   \
+    void DoPutAttribute(const std::string &entryName, const T *data,           \
+                        const Dimensions &dimensions, const int threadID)      \
+        final;
+
+    NCIO_ATTRIBUTE_DATATYPES(declare_ncio_type)
+#undef declare_ncio_type
+
+#define declare_ncio_type(T)                                                   \
     void DoPut(const std::string &entryName, const T *data,                    \
                const Dimensions &dimensions, const int threadID) final;        \
                                                                                \

--- a/source/ncio/transport/TransportNull.h
+++ b/source/ncio/transport/TransportNull.h
@@ -21,9 +21,6 @@ public:
     ~TransportNull() = default;
 
 private:
-    void
-    DoGetMetadata(std::map<std::string, std::set<std::string>> &index) final;
-
 #define declare_ncio_type(T)                                                   \
     void DoPut(const std::string &entryName, const T *data,                    \
                const Dimensions &dimensions, const int threadID) final;        \
@@ -37,6 +34,15 @@ private:
     void DoClose() final;
 
     std::any DoGetNativeHandler() noexcept final;
+
+#ifdef NCIO_HAVE_SCHEMA_NEXUS
+#define declare_ncio_type(T)                                                   \
+    void DoGetMetadataNexus(T &index, const schema::nexus::index model,        \
+                            const Parameters &parameters) final;
+
+    NCIO_MACRO_NEXUS_INDEX_MODEL(declare_ncio_type)
+#undef declare_ncio_type
+#endif
 };
 
 }

--- a/source/ncio/transport/TransportNull.tcc
+++ b/source/ncio/transport/TransportNull.tcc
@@ -1,0 +1,12 @@
+/**
+ * TransportNull.tcc
+ *
+ *  Created on: Jan 20, 2021
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#ifdef NCIO_HAVE_SCHEMA_NEXUS
+#include "ncio/schema/nexus/TransportNullNexus.tcc"
+#endif

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
@@ -225,12 +225,24 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
 
     SUBCASE("GetMetadata")
     {
-        ncio::DataDescriptor fr =
-            ncio.Open("data_async.h5", ncio::OpenMode::read);
+        const std::string fileName = "data_async.h5";
 
-        // const auto entries1 =
-        // fr.GetMetadata<ncio::schema::nexus::index::model1,
-        //                                    ncio::schema::nexus::model1_t>();
+        ncio::DataDescriptor fr = ncio.Open(fileName, ncio::OpenMode::read);
+
+        const auto entries1 = fr.GetMetadata<ncio::schema::nexus::index::model1,
+                                             ncio::schema::nexus::model1_t>();
+
+        for (const auto &entryPair : entries1)
+        {
+            std::cout << "Class: " << entryPair.first << "\n";
+
+            for (const auto &entry : entryPair.second)
+            {
+                std::cout << "\nEntry: " << entry << "\n";
+            }
+            std::cout << "\n";
+        }
+
         fr.Close();
     }
 

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
@@ -205,9 +205,21 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
 
     SUBCASE("GetNativeHandler")
     {
-        ncio::DataDescriptor fw =
+        ncio::DataDescriptor fr =
             ncio.Open("data_threads.h5", ncio::OpenMode::read);
-        std::any nativeHandler = fw.GetNativeHandler();
+        std::any nativeHandler = fr.GetNativeHandler();
+
+        fr.Close();
+    }
+
+    SUBCASE("GetMetadata")
+    {
+        ncio::DataDescriptor fr =
+            ncio.Open("data_threads.h5", ncio::OpenMode::read);
+
+        const auto entries1 = fr.GetMetadata<ncio::schema::nexus::index::model1,
+                                             ncio::schema::nexus::model1_t>();
+        fr.Close();
     }
 
 #endif

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17DataDescriptor.cpp
@@ -229,10 +229,20 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
 
         ncio::DataDescriptor fr = ncio.Open(fileName, ncio::OpenMode::read);
 
-        const auto entries1 = fr.GetMetadata<ncio::schema::nexus::index::model1,
-                                             ncio::schema::nexus::model1_t>();
+        const auto nxClassIndex =
+            fr.GetMetadata<ncio::schema::nexus::index::model1,
+                           ncio::schema::nexus::model1_t>();
 
-        for (const auto &entryPair : entries1)
+        const std::map<std::string, std::set<std::string>>
+            expectedNxClassIndex = {{"NXentry", {"/entry"}},
+                                    {"NXevent_data", {"/entry/bank1_events"}},
+                                    {"SDS",
+                                     {"/entry/bank1_events/event_id",
+                                      "/entry/bank1_events/event_index",
+                                      "/entry/bank1_events/event_time_offset",
+                                      "/entry/bank1_events/total_counts"}}};
+
+        for (const auto &entryPair : nxClassIndex)
         {
             std::cout << "Class: " << entryPair.first << "\n";
 
@@ -242,6 +252,8 @@ TEST_CASE("Functional tests for ncio::DataDescriptor C++17 bindings class")
             }
             std::cout << "\n";
         }
+
+        CHECK_EQ(nxClassIndex, expectedNxClassIndex);
 
         fr.Close();
     }

--- a/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
+++ b/testing/functional/bindings/CXX17/functionalTest_cxx17NCIO.cpp
@@ -37,14 +37,15 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
 
         // put a single value
         constexpr float totalCounts = 10;
-        fw.Put<ncio::schema::nexus::bank1::total_counts>(totalCounts);
+        fw.Put<ncio::schema::nexus::entry::bank1_events::total_counts>(
+            totalCounts);
 
         // put a 1D array
         // moving from constexpr to const, not allowed by macOS clang in CI
         const std::array<std::uint64_t, 3> eventIndex = {1, 2, 3};
         const std::size_t nx = eventIndex.size();
-        fw.Put<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
-                                                        {{nx}, {0}, {nx}});
+        fw.Put<ncio::schema::nexus::entry::bank1_events::event_index>(
+            eventIndex.data(), {{nx}, {0}, {nx}});
         fw.Execute();
         fw.Close();
     }
@@ -57,9 +58,10 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
         ncio::DataDescriptor fr =
             ncio.Open("total_counts.h5", ncio::OpenMode::read);
 
-        fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
-        fr.Get<ncio::schema::nexus::bank1::event_index>(eventIndex.data(),
-                                                        ncio::BoxAll);
+        fr.Get<ncio::schema::nexus::entry::bank1_events::total_counts>(
+            totalCounts);
+        fr.Get<ncio::schema::nexus::entry::bank1_events::event_index>(
+            eventIndex.data(), ncio::BoxAll);
         fr.Execute();
         fr.Close();
 
@@ -98,7 +100,7 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
         ncio::DataDescriptor fh = ncio.Open("null", ncio::OpenMode::write);
 
         constexpr float dataI32 = 10;
-        fh.Put<ncio::schema::nexus::bank1::total_counts>(dataI32);
+        fh.Put<ncio::schema::nexus::entry::bank1_events::total_counts>(dataI32);
         fh.Execute();
         fh.Close();
     }
@@ -107,7 +109,8 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
     {
         ncio::DataDescriptor fr = ncio.Open("null", ncio::OpenMode::read);
         float totalCounts = 0.;
-        fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts);
+        fr.Get<ncio::schema::nexus::entry::bank1_events::total_counts>(
+            totalCounts);
         fr.Execute();
         std::any handler = fr.GetNativeHandler();
         CHECK_FALSE(handler.has_value());
@@ -119,7 +122,8 @@ TEST_CASE("Functional tests for ncio::NCIO C++17 bindings class")
         ncio::DataDescriptor fr;
         float totalCounts = 0.;
         CHECK_THROWS_WITH_AS(
-            fr.Get<ncio::schema::nexus::bank1::total_counts>(totalCounts),
+            fr.Get<ncio::schema::nexus::entry::bank1_events::total_counts>(
+                totalCounts),
             "ncio ERROR: invalid DataDescriptor object in call to Get. Please "
             "modify your code and pass a valid DataDescriptor created "
             "with NCIO::Open that has not been previously closed\n",

--- a/testing/functional/bindings/CXX17/schema/nexus/functionalTest_cxx17DataDescriptorNexus.cpp
+++ b/testing/functional/bindings/CXX17/schema/nexus/functionalTest_cxx17DataDescriptorNexus.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Test Nexus schema entries")
     {
         // this will unroll to check each enum type bank_*
 #define declare_ncio_type(T)                                                   \
-    CHECK(std::is_enum<ncio::schema::nexus::bank##T>::value);
+    CHECK(std::is_enum<ncio::schema::nexus::entry::bank##T##_events>::value);
 
         NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_type)
 #undef declare_ncio_type


### PR DESCRIPTION
This PR adds two major functionalities:

- Write Attributes, needed for write/read test of schema files (NeXus)
- Read and form and in-memory index. Read `GetMetadata` enables data template models defined at compile-time. Starting with attribute-based index `map<string,set<string>>`.

To do:
Add more tests for GetMetadata functionality with actual datasets