### PR TITLE
Get vector and GetShape signatures

### DIFF
--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.cpp
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.cpp
@@ -51,7 +51,7 @@ void DataDescriptor::Close()
 }
 
 // PRIVATE
-void DataDescriptor::CheckImpl(const std::string &functionName)
+void DataDescriptor::CheckImpl(const std::string &functionName) const
 {
     if (!*this)
     {

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
@@ -93,6 +93,24 @@ public:
     void Get(T *data, const Box &box, const int threadID = 0);
 
     /**
+     * Read prefetch operation on std::vector. Cheap lazy evaluation function.
+     * Register std::vector for a particular array entry.
+     * std::vector is not populated or resized until Execute
+     * @tparam entry
+     * @tparam T
+     * @param data input data pointer to be registered, must not go out of scope
+     * of be modified until Execute
+     * @param box input dimensions selection box
+     * @param threadID
+     * @throws std::exception
+     * - std::system_error: if low-level error detected
+     * - std::invalid_argument:
+     *   - if data is nullptr
+     */
+    template <auto entry, class T>
+    void Get(std::vector<T> &data, const Box &box, const int threadID = 0);
+
+    /**
      * GetMetadata provides an application specific in-memory index.
      * @tparam schema type
      * @tparam T application specific data structure type for the metadata index

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.h
@@ -12,6 +12,7 @@
 
 #include <any>
 #include <future>
+#include <vector>
 
 namespace ncio
 {
@@ -108,7 +109,10 @@ public:
      *   - if data is nullptr
      */
     template <auto entry, class T>
-    void Get(std::vector<T> &data, const Box &box, const int threadID = 0);
+    void Get(std::vector<T> &data, const Box &box);
+
+    template <auto entry>
+    Shape GetShape() const;
 
     /**
      * GetMetadata provides an application specific in-memory index.
@@ -170,7 +174,7 @@ private:
      * @throws std::logic_error if m_ImplDataDescriptor is invalid (e.g. empty
      * constructor, after Close)
      */
-    void CheckImpl(const std::string &functionName);
+    void CheckImpl(const std::string &functionName) const;
 
     /**
      * Non-owning pimpl core object placeholder, using pointer to allow empty

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
@@ -76,13 +76,21 @@ void DataDescriptor::Get(T *data, const Box &box, const int threadID)
 }
 
 template <auto entry, class T>
-void DataDescriptor::Get(std::vector<T> &data, const Box &box,
-                         const int threadID)
+void DataDescriptor::Get(std::vector<T> &data, const Box &box)
 {
     CheckImpl("Get");
     const std::string entryName =
         m_ImplDataDescriptor->ToString<decltype(entry), entry>();
-    m_ImplDataDescriptor->Get(entryName, data, box, threadID);
+    m_ImplDataDescriptor->Get(entryName, data, box, 0);
+}
+
+template <auto entry>
+Shape DataDescriptor::GetShape() const
+{
+    CheckImpl("GetShape");
+    const std::string entryName =
+        m_ImplDataDescriptor->ToString<decltype(entry), entry>();
+    return m_ImplDataDescriptor->GetShape(entryName);
 }
 
 template <auto indexModel, class T>

--- a/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
+++ b/bindings/CXX17/ncio/cxx17/cxx17DataDescriptor.tcc
@@ -75,6 +75,16 @@ void DataDescriptor::Get(T *data, const Box &box, const int threadID)
     m_ImplDataDescriptor->Get(entryName, data, box, threadID);
 }
 
+template <auto entry, class T>
+void DataDescriptor::Get(std::vector<T> &data, const Box &box,
+                         const int threadID)
+{
+    CheckImpl("Get");
+    const std::string entryName =
+        m_ImplDataDescriptor->ToString<decltype(entry), entry>();
+    m_ImplDataDescriptor->Get(entryName, data, box, threadID);
+}
+
 template <auto indexModel, class T>
 T DataDescriptor::GetMetadata(const Parameters &parameters)
 {

--- a/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
+++ b/bindings/CXX17/ncio/cxx17/schema/nexus/cxx17DataDescriptorNexus.tcc
@@ -12,6 +12,8 @@
 #include <set>
 #include <string>
 
+#include "ncio/cxx17/cxx17DataDescriptor.h"
+
 #include "ncio/schema/nexus/ncioTypesSchemaNexus.h"
 
 namespace ncio
@@ -59,7 +61,7 @@ NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
                                                                                \
     template void                                                              \
     DataDescriptor::Get<schema::nexus::entry::bank##T##_events::event_id>(     \
-        std::uint64_t *, const Box &box, const int);                           \
+        std::uint64_t *, const Box &, const int);                              \
                                                                                \
     template void                                                              \
     DataDescriptor::Get<schema::nexus::entry::bank##T##_events::event_index>(  \
@@ -76,6 +78,42 @@ NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
     template void                                                              \
     DataDescriptor::Get<schema::nexus::entry::bank##T##_events::total_counts>( \
         float &, const int);
+
+NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
+#undef declare_ncio_types
+
+#define declare_ncio_types(T)                                                  \
+    template void                                                              \
+    DataDescriptor::Get<schema::nexus::entry::bank##T##_events::event_id>(     \
+        std::vector<std::uint64_t> &, const Box &);                            \
+                                                                               \
+    template void                                                              \
+    DataDescriptor::Get<schema::nexus::entry::bank##T##_events::event_index>(  \
+        std::vector<std::uint64_t> &, const Box &);                            \
+                                                                               \
+    template void DataDescriptor::Get<                                         \
+        schema::nexus::entry::bank##T##_events::event_time_offset>(            \
+        std::vector<float> &, const Box &);                                    \
+                                                                               \
+    template void DataDescriptor::Get<                                         \
+        schema::nexus::entry::bank##T##_events::event_time_zero>(              \
+        std::vector<double> &, const Box &);
+
+NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
+#undef declare_ncio_types
+
+#define declare_ncio_types(T)                                                  \
+    template Shape DataDescriptor::GetShape<                                   \
+        schema::nexus::entry::bank##T##_events::event_id>() const;             \
+                                                                               \
+    template Shape DataDescriptor::GetShape<                                   \
+        schema::nexus::entry::bank##T##_events::event_index>() const;          \
+                                                                               \
+    template Shape DataDescriptor::GetShape<                                   \
+        schema::nexus::entry::bank##T##_events::event_time_offset>() const;    \
+                                                                               \
+    template Shape DataDescriptor::GetShape<                                   \
+        schema::nexus::entry::bank##T##_events::event_time_zero>() const;
 
 NCIO_MACRO_NEXUS_FOREACH_BANK_ID(declare_ncio_types)
 #undef declare_ncio_types

--- a/source/ncio/common/ncioTypes.h
+++ b/source/ncio/common/ncioTypes.h
@@ -68,4 +68,13 @@ enum class DataType
     float64
 };
 
+/** The long-term goal is to enable higher-level memory contiguous containers
+ *  (e.g. smart pointers) */
+enum class ContainerType
+{
+    reference, ///< used for values only
+    pointer,
+    std_vector,
+};
+
 } // end namespace ncio

--- a/source/ncio/core/DataDescriptor.cpp
+++ b/source/ncio/core/DataDescriptor.cpp
@@ -159,12 +159,13 @@ std::any DataDescriptor::GetNativeHandler() noexcept
 bool DataDescriptor::IsOpen() const noexcept { return m_IsOpen; }
 
 // PRIVATE
-DataDescriptor::Entry::Entry(const DataType dataType, std::any data,
+DataDescriptor::Entry::Entry(const DataType dataType,
+                             const ContainerType containerType, std::any data,
                              const std::variant<Dimensions, Box> &query,
                              const ShapeType shapeType,
                              const Parameters &parameters, Info *info)
-: dataType(dataType), data(data), query(query), shapeType(shapeType),
-  parameters(parameters), info(info)
+: dataType(dataType), containerType(containerType), data(data), query(query),
+  shapeType(shapeType), parameters(parameters), info(info)
 {
 }
 

--- a/source/ncio/core/DataDescriptor.cpp
+++ b/source/ncio/core/DataDescriptor.cpp
@@ -34,6 +34,18 @@ DataDescriptor::DataDescriptor(const std::string &descriptorName,
     InitTransport(descriptorName, openMode, parameters);
 }
 
+Shape DataDescriptor::GetShape(const std::string &entryName) const
+{
+    if (m_OpenMode != OpenMode::read)
+    {
+        throw std::logic_error(
+            "ncio ERROR: DataDescriptor::GetShape function can only be called "
+            "in a DataDescriptor created with OpenMode::read\n");
+    }
+
+    return m_Transport->GetShape(entryName);
+}
+
 void DataDescriptor::Execute(const int threadID)
 {
     auto lf_ExecutePutAttributes =
@@ -101,10 +113,10 @@ void DataDescriptor::Execute(const int threadID)
                         // avoid warning
                     case (DataType::string):
                         break;
+                    // FIXME: use GetEntry
 #define declare_ncio_types(T, L)                                               \
     case (T):                                                                  \
-        m_Transport->Get<L>(entryName, std::any_cast<L *>(request.data), box,  \
-                            threadID);                                         \
+        GetEntry<L>(entryName, request, threadID);                             \
         break;
 
                         NCIO_PRIMITIVE_DATATYPES_2ARGS(declare_ncio_types)

--- a/source/ncio/core/DataDescriptor.h
+++ b/source/ncio/core/DataDescriptor.h
@@ -56,6 +56,10 @@ public:
     void Get(const std::string &entryName, T *data, const Box &box,
              const int threadID);
 
+    template <class T>
+    void Get(const std::string &entryName, std::vector<T> &data, const Box &box,
+             const int threadID);
+
     template <class Enum, Enum indexModel, class T>
     T GetMetadata(const Parameters &parameters);
 
@@ -126,15 +130,16 @@ private:
      */
     struct Entry
     {
-        const DataType dataType; ///< data type
+        const DataType dataType;           ///< fixed width data type
+        const ContainerType containerType; ///< reference, pointer, vector
         std::any data; ///< hold data pointer or value from application
         const std::variant<Dimensions, Box> query; ///< request query
         const ShapeType shapeType;
         const Parameters parameters; ///< optional parameters (e.g. compression)
         Info *info;                  // TODO
 
-        Entry(const DataType dataType, std::any data,
-              const std::variant<Dimensions, Box> &query,
+        Entry(const DataType dataType, const ContainerType containerType,
+              std::any data, const std::variant<Dimensions, Box> &query,
               const ShapeType shapeType, const Parameters &parameters,
               Info *info);
     };

--- a/source/ncio/core/DataDescriptor.h
+++ b/source/ncio/core/DataDescriptor.h
@@ -60,6 +60,8 @@ public:
     void Get(const std::string &entryName, std::vector<T> &data, const Box &box,
              const int threadID);
 
+    Shape GetShape(const std::string &entryName) const;
+
     template <class Enum, Enum indexModel, class T>
     T GetMetadata(const Parameters &parameters);
 

--- a/source/ncio/core/DataDescriptor.tcc
+++ b/source/ncio/core/DataDescriptor.tcc
@@ -11,10 +11,13 @@
 #include "DataDescriptor.h"
 
 #include "ncio/common/ncioTypes.h" // Dimensions
+#include "ncio/helper/ncioHelperMath.h"
 #include "ncio/helper/ncioHelperTypes.h"
 #include "ncio/transport/Transport.h"
 
 #include "ncio/ncioConfig.h"
+
+#include <cassert>
 
 namespace ncio::core
 {
@@ -99,7 +102,7 @@ void DataDescriptor::Get(const std::string &entryName, std::vector<T> &data,
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
     m_Entries[threadID][entryName].emplace_back(
-        helper::types::ToDataTypeEnum<T>(), ContainerType::std_vector, data,
+        helper::types::ToDataTypeEnum<T>(), ContainerType::std_vector, &data,
         box, ShapeType::array, Parameters(), nullptr);
 }
 
@@ -111,7 +114,10 @@ void DataDescriptor::Get(const std::string &entryName, std::vector<T> &data,
                                                                                \
     template void DataDescriptor::Get(const std::string &, T *, const int);    \
     template void DataDescriptor::Get(const std::string &, T *, const Box &,   \
-                                      const int);
+                                      const int);                              \
+                                                                               \
+    template void DataDescriptor::Get(const std::string &, std::vector<T> &,   \
+                                      const Box &, const int);
 
 NCIO_PRIMITIVE_TYPES(declare_ncio_type)
 #undef declare_ncio_type
@@ -179,23 +185,59 @@ void DataDescriptor::GetEntry(const std::string &entryName, Entry &entry,
     switch (entry.shapeType)
     {
     case (ShapeType::value): {
-        T *data = std::any_cast<T>(&entry.data);
+        T *data = std::any_cast<T *>(entry.data);
+
         // TODO: rethink when backends allow truly threaded code
         std::lock_guard<std::mutex> lock(m_Mutex);
         {
-            m_Transport->Get(entryName, data, DimensionsValue, threadID);
+            m_Transport->Get(entryName, data, BoxValue, threadID);
         }
         break;
     }
     case (ShapeType::array): {
-        // TODO some checks on Dimensions
-        T *data = std::any_cast<T *>(entry.data);
-        // TODO: rethink when backends allow truly threaded code
-        std::lock_guard<std::mutex> lock(m_Mutex);
+
+        switch (entry.containerType)
         {
-            m_Transport->Get(entryName, data, std::get<Box>(entry.query),
-                             threadID);
+        case (ContainerType::pointer): {
+            // TODO some checks on Dimensions
+            T *data = std::any_cast<T *>(entry.data);
+            // TODO: rethink when backends allow truly threaded code
+            std::lock_guard<std::mutex> lock(m_Mutex);
+            {
+                m_Transport->Get(entryName, data, std::get<Box>(entry.query),
+                                 threadID);
+            }
+            break;
         }
+        case (ContainerType::std_vector): {
+
+            // must resize
+            // TODO some checks on Dimensions
+            std::vector<T> &data = *std::any_cast<std::vector<T> *>(entry.data);
+            // TODO: rethink when backends allow truly threaded code
+            std::lock_guard<std::mutex> lock(m_Mutex);
+            {
+                const Box box = std::get<Box>(entry.query); // box request
+                // dimensions array for the corresponding box selection
+                const Count count =
+                    (box == ncio::BoxAll)
+                        ? m_Transport->GetShape(
+                              entryName)    // get the entire array shape
+                        : std::get<1>(box); // get the box count
+
+                const std::size_t totalElements = helper::math::Product(count);
+                data.resize(totalElements);
+                m_Transport->Get(entryName, data.data(), box, threadID);
+            }
+            break;
+        }
+
+        default: {
+            assert(entry.containerType != ContainerType::reference);
+        }
+
+        } // end containerType switch
+
         break;
     }
     }

--- a/source/ncio/core/DataDescriptor.tcc
+++ b/source/ncio/core/DataDescriptor.tcc
@@ -30,9 +30,9 @@ void DataDescriptor::PutAttribute(const std::string &entryName, const T &data,
     }
     std::lock_guard<std::mutex> lock(m_Mutex);
     m_Attributes.emplace(entryName,
-                         Entry(helper::types::ToDataTypeEnum<T>(), data,
-                               DimensionsValue, ShapeType::value, Parameters(),
-                               nullptr));
+                         Entry(helper::types::ToDataTypeEnum<T>(),
+                               ContainerType::reference, data, DimensionsValue,
+                               ShapeType::value, Parameters(), nullptr));
 }
 
 template <class T>
@@ -59,8 +59,8 @@ void DataDescriptor::Put(const std::string &entryName, const T &data,
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
     m_Entries[threadID][entryName].emplace_back(
-        helper::types::ToDataTypeEnum<T>(), data, DimensionsValue,
-        ShapeType::value, Parameters(), nullptr);
+        helper::types::ToDataTypeEnum<T>(), ContainerType::reference, data,
+        DimensionsValue, ShapeType::value, Parameters(), nullptr);
 }
 
 template <class T>
@@ -69,8 +69,8 @@ void DataDescriptor::Put(const std::string &entryName, const T *data,
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
     m_Entries[threadID][entryName].emplace_back(
-        helper::types::ToDataTypeEnum<T>(), data, dimensions, ShapeType::array,
-        Parameters(), nullptr);
+        helper::types::ToDataTypeEnum<T>(), ContainerType::pointer, data,
+        dimensions, ShapeType::array, Parameters(), nullptr);
 }
 
 template <class T>
@@ -79,8 +79,8 @@ void DataDescriptor::Get(const std::string &entryName, T *data,
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
     m_Entries[threadID][entryName].emplace_back(
-        helper::types::ToDataTypeEnum<T>(), data, BoxValue, ShapeType::value,
-        Parameters(), nullptr);
+        helper::types::ToDataTypeEnum<T>(), ContainerType::pointer, data,
+        BoxValue, ShapeType::value, Parameters(), nullptr);
 }
 
 template <class T>
@@ -89,8 +89,18 @@ void DataDescriptor::Get(const std::string &entryName, T *data, const Box &box,
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
     m_Entries[threadID][entryName].emplace_back(
-        helper::types::ToDataTypeEnum<T>(), data, box, ShapeType::array,
-        Parameters(), nullptr);
+        helper::types::ToDataTypeEnum<T>(), ContainerType::pointer, data, box,
+        ShapeType::array, Parameters(), nullptr);
+}
+
+template <class T>
+void DataDescriptor::Get(const std::string &entryName, std::vector<T> &data,
+                         const Box &box, const int threadID)
+{
+    std::lock_guard<std::mutex> lock(m_Mutex);
+    m_Entries[threadID][entryName].emplace_back(
+        helper::types::ToDataTypeEnum<T>(), ContainerType::std_vector, data,
+        box, ShapeType::array, Parameters(), nullptr);
 }
 
 #define declare_ncio_type(T)                                                   \

--- a/source/ncio/helper/ncioHelperMath.cpp
+++ b/source/ncio/helper/ncioHelperMath.cpp
@@ -1,0 +1,12 @@
+/*
+ * ncioHelperMath.cpp
+ *
+ *  Created on: Mar 11, 2021
+ *      Author: wgodoy
+ */
+
+#include "ncioHelperMath.h"
+#include "ncioHelperMath.tcc"
+
+namespace ncio::helper::math
+{}

--- a/source/ncio/helper/ncioHelperMath.h
+++ b/source/ncio/helper/ncioHelperMath.h
@@ -1,0 +1,26 @@
+/**
+ * ncioHelperVector.h
+ *
+ *  Created on: Mar 11, 2021
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <vector>
+
+namespace ncio::helper::math
+{
+
+/**
+ * Calculate the product of all elements in a std::vector. Restricted to
+ * integral types.
+ * @tparam T supported numerical type
+ * @param elements input vector of elements {nx, ny, nz}
+ * @return product nx . ny . nz
+ */
+template <class T>
+T Product(const std::vector<T> &elements);
+
+} // end namespace

--- a/source/ncio/helper/ncioHelperMath.tcc
+++ b/source/ncio/helper/ncioHelperMath.tcc
@@ -1,0 +1,32 @@
+/**
+ * ncioHelperVector.h
+ *
+ *  Created on: Mar 11, 2021
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#pragma once
+
+#include "ncioHelperMath.h"
+
+#include <vector>
+
+namespace ncio::helper::math
+{
+
+template <class T>
+T Product(const std::vector<T> &elements)
+{
+    static_assert(std::is_arithmetic_v<T>,
+                  "only arithmetic values are allowed");
+    T product = T(1);
+    for (const T &element : elements)
+    {
+        product *= element;
+    }
+    return product;
+}
+
+template std::size_t Product(const std::vector<std::size_t> &);
+
+} // end namespace

--- a/source/ncio/meson.build
+++ b/source/ncio/meson.build
@@ -47,6 +47,7 @@ ncio_sources = ['core/NCIO.cpp',
                 
                 'helper/ncioHelperString.cpp',
                 'helper/ncioHelperTypes.cpp',
+                'helper/ncioHelperMath.cpp',
                 
                 'transport/Transport.cpp',
                 'transport/TransportNull.cpp']

--- a/source/ncio/transport/Transport.cpp
+++ b/source/ncio/transport/Transport.cpp
@@ -26,6 +26,11 @@ void Transport::Close()
     m_IsOpen = false;
 }
 
+Shape Transport::GetShape(const std::string &entryName) const
+{
+    return DoGetShape(entryName);
+}
+
 std::any Transport::GetNativeHandler() noexcept { return DoGetNativeHandler(); }
 
 }

--- a/source/ncio/transport/Transport.h
+++ b/source/ncio/transport/Transport.h
@@ -47,6 +47,10 @@ public:
     template <class Enum, Enum indexModel, class T>
     T GetMetadata(const Parameters &parameters);
 
+    // this could be expanded to getting more entry info, for now dimensions as
+    // it's used for reallocating memory
+    Shape GetShape(const std::string &entryName) const;
+
     template <class T>
     void PutAttribute(const std::string &entryName, const T *data,
                       const Dimensions &dimensions, const int threadID);
@@ -86,6 +90,8 @@ protected:
 
     /** flag to check if m_File is open and close it in destructor (RAII) */
     bool m_IsOpen = false;
+
+    virtual Shape DoGetShape(const std::string &entryName) const = 0;
 
 #define declare_ncio_type(T)                                                   \
     virtual void DoPutAttribute(const std::string &attributeName,              \

--- a/source/ncio/transport/TransportHDF5.cpp
+++ b/source/ncio/transport/TransportHDF5.cpp
@@ -72,6 +72,29 @@ TransportHDF5::~TransportHDF5()
 }
 
 // PRIVATE
+Shape TransportHDF5::DoGetShape(const std::string &entryName) const
+{
+    hid_t dataSetID = H5Dopen(m_File, entryName.c_str(), H5P_DEFAULT);
+    hid_t dataspaceID = H5Dget_space(dataSetID);
+    const std::size_t nDimensions =
+        static_cast<std::size_t>(H5Sget_simple_extent_ndims(dataspaceID));
+
+    std::vector<unsigned long long int> shapeInt(nDimensions);
+    H5Sget_simple_extent_dims(dataspaceID, shapeInt.data(), NULL);
+
+    Shape shape;
+    shape.reserve(nDimensions);
+
+    for (const auto dimension : shapeInt)
+    {
+        shape.push_back(dimension);
+    }
+
+    H5Sclose(dataspaceID);
+    H5Dclose(dataSetID);
+
+    return shape;
+}
 
 #define declare_ncio_type(T)                                                   \
     void TransportHDF5::DoPutAttribute(                                        \

--- a/source/ncio/transport/TransportHDF5.h
+++ b/source/ncio/transport/TransportHDF5.h
@@ -34,6 +34,8 @@ private:
     /** generated Id for top level group "/" */
     hid_t m_TopGroupID = -1;
 
+    Shape DoGetShape(const std::string &entryName) const;
+
 #define declare_ncio_type(T)                                                   \
     void DoPutAttribute(const std::string &attributeName, const T *data,       \
                         const Dimensions &dimensions, const int threadID)      \

--- a/source/ncio/transport/TransportNull.cpp
+++ b/source/ncio/transport/TransportNull.cpp
@@ -45,6 +45,11 @@ NCIO_PRIMITIVE_TYPES(declare_ncio_types)
 
 void TransportNull::DoClose() {}
 
+Shape TransportNull::DoGetShape(const std::string &entryName) const
+{
+    return Shape();
+}
+
 std::any TransportNull::DoGetNativeHandler() noexcept { return std::any(); }
 
 } // end namespace ncio::transport

--- a/source/ncio/transport/TransportNull.h
+++ b/source/ncio/transport/TransportNull.h
@@ -21,6 +21,8 @@ public:
     ~TransportNull() = default;
 
 private:
+    Shape DoGetShape(const std::string &entryName) const;
+
 #define declare_ncio_type(T)                                                   \
     void DoPutAttribute(const std::string &entryName, const T *data,           \
                         const Dimensions &dimensions, const int threadID)      \

--- a/testing/ci/unit/meson.build
+++ b/testing/ci/unit/meson.build
@@ -1,7 +1,7 @@
 
 # key: suite, value: list of tests
 unit_tests = { 'core' : ['NCIO'], 
-               'helper' : ['ncioHelperString']
+               'helper' : ['ncioHelperString', 'ncioHelperTypes', 'ncioHelperMath']
              }
 
 foreach key, value: unit_tests

--- a/testing/ci/unit/ncio/helper/unitTest_ncioHelperMath.cpp
+++ b/testing/ci/unit/ncio/helper/unitTest_ncioHelperMath.cpp
@@ -1,0 +1,32 @@
+/**
+ * unitTest_ncioHelperMath.cpp:
+ *
+ *  Created on: Mar 11, 2021
+ *      Author: William F Godoy godoywf@ornl.gov
+ *     License: BSD-3-Clause
+ */
+
+#include "ncio-doctest.h"
+
+#include "ncio/helper/ncioHelperMath.h"
+
+#include <cstdint>
+
+namespace ncio::testing::unit::helper
+{
+
+TEST_CASE("Unit test for ncio::helper::math functions")
+{
+    SUBCASE("Product")
+    {
+        const std::vector<std::size_t> input = {1, 2, 3};
+        CHECK_EQ(ncio::helper::math::Product(input), 6);
+    }
+    SUBCASE("ZeroProduct")
+    {
+        const std::vector<std::size_t> input = {1, 2, 0};
+        CHECK_EQ(ncio::helper::math::Product(input), 0);
+    }
+}
+
+}

--- a/testing/ci/unit/ncio/helper/unitTest_ncioHelperString.cpp
+++ b/testing/ci/unit/ncio/helper/unitTest_ncioHelperString.cpp
@@ -5,6 +5,7 @@
  *      Author: William F Godoy godoywf@ornl.gov
  *     License: BSD-3-Clause
  */
+
 #include "ncio-doctest.h"
 
 #include "ncio/helper/ncioHelperString.h"

--- a/testing/ci/unit/ncio/helper/unitTest_ncioHelperTypes.cpp
+++ b/testing/ci/unit/ncio/helper/unitTest_ncioHelperTypes.cpp
@@ -1,0 +1,48 @@
+/**
+ * unitTest_ncioHelperTypes.cpp
+ *
+ *  Created on: Mar 11, 2021
+ *      Author: William F Godoy godoywf@ornl.gov
+ *     License: BSD-3-Clause
+ */
+
+#include "ncio-doctest.h"
+
+#include "ncio/common/ncioTypes.h"
+#include "ncio/helper/ncioHelperTypes.h"
+
+#include <iostream>
+
+namespace ncio::testing::unit::helper
+{
+
+TEST_CASE("Unit test for ncio::helper::types functions")
+{
+    SUBCASE("ToDataTypeEnum")
+    {
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::string>(),
+                 ncio::DataType::string);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::int8_t>(),
+                 ncio::DataType::int8);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::int16_t>(),
+                 ncio::DataType::int16);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::int32_t>(),
+                 ncio::DataType::int32);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::int64_t>(),
+                 ncio::DataType::int64);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::uint8_t>(),
+                 ncio::DataType::uint8);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::uint16_t>(),
+                 ncio::DataType::uint16);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::uint32_t>(),
+                 ncio::DataType::uint32);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<std::uint64_t>(),
+                 ncio::DataType::uint64);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<float>(),
+                 ncio::DataType::float32);
+        CHECK_EQ(ncio::helper::types::ToDataTypeEnum<double>(),
+                 ncio::DataType::float64);
+    }
+}
+
+} // end namespace


### PR DESCRIPTION
`Get` `std::vector` allows automatic reallocation if required, doesn't allow SIMD due to reallocation.
`GetShape` returns the `Shape` of an entry if outside allocation is required
Added functional and unit tests